### PR TITLE
8316738: java/net/httpclient/HttpClientLocalAddrTest.java failed in timeout

### DIFF
--- a/test/jdk/java/net/httpclient/HttpClientLocalAddrTest.java
+++ b/test/jdk/java/net/httpclient/HttpClientLocalAddrTest.java
@@ -64,6 +64,7 @@ import static java.net.http.HttpClient.Version.HTTP_2;
  *      -Djdk.httpclient.HttpClient.log=frames,ssl,requests,responses,errors
  *      -Djdk.internal.httpclient.debug=true
  *      -Dsun.net.httpserver.idleInterval=50000
+ *      -Djdk.tracePinnedThreads=full
  *      HttpClientLocalAddrTest
  *
  * @run testng/othervm/java.security.policy=httpclient-localaddr-security.policy


### PR DESCRIPTION
Requesting backport to JDK 22 of this test-only change.

This pull request contains a backport of commit [f577385f](https://github.com/openjdk/jdk/commit/f577385fc8d5a6f4c47d88e8f9166a7b76d1246e) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jaikiran Pai on 8 Dec 2023 and was reviewed by Daniel Fuchs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316738](https://bugs.openjdk.org/browse/JDK-8316738): java/net/httpclient/HttpClientLocalAddrTest.java failed in timeout (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/2/head:pull/2` \
`$ git checkout pull/2`

Update a local copy of the PR: \
`$ git checkout pull/2` \
`$ git pull https://git.openjdk.org/jdk22.git pull/2/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2`

View PR using the GUI difftool: \
`$ git pr show -t 2`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/2.diff">https://git.openjdk.org/jdk22/pull/2.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/2#issuecomment-1846935872)