### PR TITLE
8321739: Source launcher fails with "Not a directory" error

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/MemoryContext.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/MemoryContext.java
@@ -177,7 +177,7 @@ final class MemoryContext {
         var file = descriptor.sourceRootPath().resolve(path);
 
         // Trivial case: no matching source file exists
-        if (Files.notExists(file)) return null;
+        if (!Files.exists(file)) return null;
 
         // Compile source file (unit) with similar options as the program.
         var opts = options.forSubsequentCompilations();

--- a/test/langtools/tools/javac/launcher/GetResourceTest.java
+++ b/test/langtools/tools/javac/launcher/GetResourceTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8210009
+ * @bug 8210009 8321739
  * @summary Source Launcher classloader should support getResource and getResourceAsStream
  * @enablePreview
  * @modules jdk.compiler
@@ -41,7 +41,7 @@ import toolbox.ToolBox;
 
 /*
  * The body of this test is in ${test.src}/src/p/q/CLTest.java,
- * which is executed in single-file source-launcher mode,
+ * which is executed in source-launcher mode,
  * in order to test the classloader used to launch such programs.
  */
 public class GetResourceTest {

--- a/test/langtools/tools/javac/launcher/src/java
+++ b/test/langtools/tools/javac/launcher/src/java
@@ -1,0 +1,1 @@
+A text file named `java` to simulate https://bugs.openjdk.org/browse/JDK-8321739


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [df4ed7ef](https://github.com/openjdk/jdk/commit/df4ed7eff7cc4afb2f0bcfdbb2489715ab209737) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Christian Stein on 12 Dec 2023 and was reviewed by Jan Lahoda.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321739](https://bugs.openjdk.org/browse/JDK-8321739): Source launcher fails with "Not a directory" error (**Bug** - P3)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/10/head:pull/10` \
`$ git checkout pull/10`

Update a local copy of the PR: \
`$ git checkout pull/10` \
`$ git pull https://git.openjdk.org/jdk22.git pull/10/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10`

View PR using the GUI difftool: \
`$ git pr show -t 10`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/10.diff">https://git.openjdk.org/jdk22/pull/10.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/10#issuecomment-1852295361)