### PR TITLE
8320682: [AArch64] C1 compilation fails with "Field too big for insn"

### DIFF
--- a/src/hotspot/share/c1/c1_globals.hpp
+++ b/src/hotspot/share/c1/c1_globals.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -275,9 +275,11 @@
   develop(bool, InstallMethods, true,                                       \
           "Install methods at the end of successful compilations")          \
                                                                             \
+  /* The compiler assumes, in many places, that methods are at most 1MB. */ \
+  /* Therefore, we restrict this flag to at most 1MB.                    */ \
   develop(intx, NMethodSizeLimit, (64*K)*wordSize,                          \
           "Maximum size of a compiled method.")                             \
-          range(0, max_jint)                                                \
+          range(0, 1*M)                                                     \
                                                                             \
   develop(bool, TraceFPUStack, false,                                       \
           "Trace emulation of the FPU stack (intel only)")                  \

--- a/test/hotspot/jtreg/compiler/arguments/TestC1Globals.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestC1Globals.java
@@ -23,31 +23,11 @@
 
 /**
  * @test
- * @bug 8318817
- * @requires vm.debug
- * @summary Test flag with large value
- *
- * @run main/othervm -XX:NMethodSizeLimit=351658240
- *                   compiler.arguments.TestC1Globals
- */
-
-/**
- * @test
- * @bug 8318817
- * @requires vm.debug
- * @summary Test flag with large value
- *
- * @run main/othervm -XX:NMethodSizeLimit=224001703
- *                   compiler.arguments.TestC1Globals
- */
-
-/**
- * @test
  * @bug 8316653
  * @requires vm.debug
- * @summary Test flag with max value
+ * @summary Test flag with max value.
  *
- * @run main/othervm -XX:NMethodSizeLimit=2147483647
+ * @run main/othervm -XX:NMethodSizeLimit=1M
  *                   compiler.arguments.TestC1Globals
  */
 
@@ -56,25 +36,23 @@
  * @bug 8318817
  * @requires vm.debug
  * @requires os.family == "linux"
- * @summary Test flag with large value combined with transparent huge pages on
+ * @summary Test flag with max value combined with transparent huge pages on
  *          Linux.
  *
- * @run main/othervm -XX:NMethodSizeLimit=351658240
+ * @run main/othervm -XX:NMethodSizeLimit=1M
  *                   -XX:+UseTransparentHugePages
  *                   compiler.arguments.TestC1Globals
- *
  */
 
 /**
  * @test
- * @bug 8318817
+ * @bug 8320682
  * @requires vm.debug
- * @requires os.family == "linux"
- * @summary Test flag with large value combined with transparent huge pages on
- *          Linux.
+ * @summary Test flag with max value and specific compilation.
  *
- * @run main/othervm -XX:NMethodSizeLimit=224001703
- *                   -XX:+UseTransparentHugePages
+ * @run main/othervm -XX:NMethodSizeLimit=1M
+ *                   -XX:CompileOnly=java.util.HashMap::putMapEntries
+ *                   -Xcomp
  *                   compiler.arguments.TestC1Globals
  *
  */


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [69014cd5](https://github.com/openjdk/jdk/commit/69014cd55b59a0a63f4918fad575a6887640573e) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Daniel Lundén on 14 Dec 2023 and was reviewed by Tobias Hartmann, Andrew Haley and Dean Long.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320682](https://bugs.openjdk.org/browse/JDK-8320682): [AArch64] C1 compilation fails with "Field too big for insn" (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/15/head:pull/15` \
`$ git checkout pull/15`

Update a local copy of the PR: \
`$ git checkout pull/15` \
`$ git pull https://git.openjdk.org/jdk22.git pull/15/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15`

View PR using the GUI difftool: \
`$ git pr show -t 15`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/15.diff">https://git.openjdk.org/jdk22/pull/15.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/15#issuecomment-1857690704)