### PR TITLE
8321958: @param/@return descriptions of ZoneRules#isDaylightSavings() are incorrect

### DIFF
--- a/src/java.base/share/classes/java/time/zone/ZoneRules.java
+++ b/src/java.base/share/classes/java/time/zone/ZoneRules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -828,9 +828,9 @@ public final class ZoneRules implements Serializable {
      * This default implementation compares the {@link #getOffset(java.time.Instant) actual}
      * and {@link #getStandardOffset(java.time.Instant) standard} offsets.
      *
-     * @param instant  the instant to find the offset information for, not null, but null
+     * @param instant  the instant to check the daylight savings for, not null, but null
      *  may be ignored if the rules have a single offset for all instants
-     * @return the standard offset, not null
+     * @return true if the specified instant is in daylight savings, false otherwise.
      */
     public boolean isDaylightSavings(Instant instant) {
         return (getStandardOffset(instant).equals(getOffset(instant)) == false);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8322044](https://bugs.openjdk.org/browse/JDK-8322044) to be approved

### Issues
 * [JDK-8321958](https://bugs.openjdk.org/browse/JDK-8321958): @<!---->param/@<!---->return descriptions of ZoneRules#isDaylightSavings() are incorrect (**Bug** - P4)
 * [JDK-8322044](https://bugs.openjdk.org/browse/JDK-8322044): @<!---->param/@<!---->return descriptions of ZoneRules#isDaylightSavings() are incorrect (**CSR**)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/16/head:pull/16` \
`$ git checkout pull/16`

Update a local copy of the PR: \
`$ git checkout pull/16` \
`$ git pull https://git.openjdk.org/jdk22.git pull/16/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16`

View PR using the GUI difftool: \
`$ git pr show -t 16`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/16.diff">https://git.openjdk.org/jdk22/pull/16.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/16#issuecomment-1858253884)