### PR TITLE
8321514: UTF16 string gets constructed incorrectly from codepoints if CompactStrings is not enabled

### DIFF
--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -420,7 +420,7 @@ final class StringUTF16 {
         int n = computeCodePointSize(val, index, end);
 
         byte[] buf = newBytesFor(n);
-        return extractCodepoints(val, index, len, buf, 0);
+        return extractCodepoints(val, index, end, buf, 0);
      }
 
     public static byte[] toBytes(char c) {

--- a/test/jdk/java/lang/String/Chars.java
+++ b/test/jdk/java/lang/String/Chars.java
@@ -23,8 +23,10 @@
 
 /*
  * @test
- * @bug 8054307 8311906
+ * @bug 8054307 8311906 8321514
  * @summary test String chars() and codePoints()
+ * @run main/othervm -XX:+CompactStrings Chars
+ * @run main/othervm -XX:-CompactStrings Chars
  */
 
 import java.util.Arrays;
@@ -45,6 +47,7 @@ public class Chars {
             }
             testChars(cc, ccExp);
             testCharsSubrange(cc, ccExp);
+            testIntsSubrange(ccExp);
             testCPs(cc, cpExp);
 
             // bmp without surrogates
@@ -72,6 +75,7 @@ public class Chars {
             cpExp = Arrays.copyOf(cpExp, k);
             testChars(cc, ccExp);
             testCharsSubrange(cc, ccExp);
+            testIntsSubrange(ccExp);
             testCPs(cc, cpExp);
         }
     }
@@ -100,6 +104,27 @@ public class Chars {
                 System.err.println("expected: " + Arrays.toString(expected));
                 System.err.println("actual: " + Arrays.toString(actual));
                 throw new RuntimeException("testCharsSubrange failed!");
+            }
+        }
+    }
+
+    static void testIntsSubrange(int[] expected) {
+        int[] offsets = { 7, 31 };   // offsets to test
+        int LENGTH = 13;
+        for (int i = 0; i < offsets.length; i++) {
+            int offset = Math.max(0, offsets[i]);       // confine to the input array
+            int count = Math.min(LENGTH, expected.length - offset);
+            String str = new String(expected, offset, count);
+            int[] actual = str.chars().toArray();
+            int errOffset = Arrays.mismatch(actual, 0, actual.length,
+                    expected, offset, offset + count);
+            if (errOffset >= 0) {
+                System.err.printf("expected[%d] (%d) != actual[%d] (%d)%n",
+                        offset + errOffset, expected[offset + errOffset],
+                        errOffset, actual[errOffset]);
+                System.err.println("expected: " + Arrays.toString(expected));
+                System.err.println("actual: " + Arrays.toString(actual));
+                throw new RuntimeException("testIntsSubrange failed!");
             }
         }
     }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [fde5b168](https://github.com/openjdk/jdk/commit/fde5b16817c3263236993f2e8c2d2469610d99bd) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Aleksei Voitylov on 14 Dec 2023 and was reviewed by Roger Riggs.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321514](https://bugs.openjdk.org/browse/JDK-8321514): UTF16 string gets constructed incorrectly from codepoints if CompactStrings is not enabled (**Bug** - P2)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/18/head:pull/18` \
`$ git checkout pull/18`

Update a local copy of the PR: \
`$ git checkout pull/18` \
`$ git pull https://git.openjdk.org/jdk22.git pull/18/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18`

View PR using the GUI difftool: \
`$ git pr show -t 18`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/18.diff">https://git.openjdk.org/jdk22/pull/18.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/18#issuecomment-1860302473)