### PR TITLE
8322647: Short name for the `Europe/Lisbon` time zone is incorrect

### DIFF
--- a/test/jdk/java/time/test/java/time/format/TestUTCParse.java
+++ b/test/jdk/java/time/test/java/time/format/TestUTCParse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 /*
  * @test
  * @modules jdk.localedata
- * @bug 8303440 8317979
+ * @bug 8303440 8317979 8322647
  * @summary Test parsing "UTC-XX:XX" text works correctly
  */
 package test.java.time.format;
@@ -43,8 +43,8 @@ import static org.testng.Assert.assertEquals;
 public class TestUTCParse {
 
     static {
-        // Assuming CLDR's SHORT name for "America/Juneau"
-        // produces "UTC\u212209:00"
+        // Assuming CLDR's SHORT name for "America/Manaus"
+        // produces "UTC\u221204:00"
         System.setProperty("java.locale.providers", "CLDR");
     }
 
@@ -60,9 +60,9 @@ public class TestUTCParse {
     @Test
     public void testUTCShortNameRoundTrip() {
         var fmt = DateTimeFormatter.ofPattern("z", Locale.FRANCE);
-        var zdt = ZonedDateTime.of(2023, 3, 3, 0, 0, 0, 0, ZoneId.of("America/Juneau"));
+        var zdt = ZonedDateTime.of(2023, 3, 3, 0, 0, 0, 0, ZoneId.of("America/Manaus"));
         var formatted = fmt.format(zdt);
-        assertEquals(formatted, "UTC\u221209:00");
+        assertEquals(formatted, "UTC\u221204:00");
         assertEquals(fmt.parse(formatted).query(TemporalQueries.zoneId()), zdt.getZone());
     }
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322647](https://bugs.openjdk.org/browse/JDK-8322647): Short name for the `Europe/Lisbon` time zone is incorrect (**Bug** - P3)


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/30/head:pull/30` \
`$ git checkout pull/30`

Update a local copy of the PR: \
`$ git checkout pull/30` \
`$ git pull https://git.openjdk.org/jdk22.git pull/30/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30`

View PR using the GUI difftool: \
`$ git pr show -t 30`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/30.diff">https://git.openjdk.org/jdk22/pull/30.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/30#issuecomment-1877498751)