### PR TITLE
8322142: JFR: Periodic tasks aren't orphaned between recordings

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/BatchManager.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/BatchManager.java
@@ -63,11 +63,7 @@ final class BatchManager {
         }
         for (PeriodicTask task : activeSortedTasks(tasks)) {
             if (task.isSchedulable()) {
-                Batch batch = task.getBatch();
-                // If new task, or period has changed, find new batch
-                if (batch == null) {
-                    batch = findBatch(task.getPeriod());
-                }
+                Batch batch = findBatch(task.getPeriod(), task.getBatch());
                 batch.add(task);
             }
         }
@@ -89,7 +85,7 @@ final class BatchManager {
         return tasks;
     }
 
-    private Batch findBatch(long period) {
+    private Batch findBatch(long period, Batch oldBatch) {
         // All events with a period less than 1000 ms
         // get their own unique batch. The rationale for
         // this is to avoid a scenario where a user (mistakenly) specifies
@@ -102,7 +98,7 @@ final class BatchManager {
                 return batch;
             }
         }
-        Batch batch = new Batch(period);
+        Batch batch = oldBatch != null ? oldBatch : new Batch(period);
         batches.add(batch);
         return batch;
     }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322142](https://bugs.openjdk.org/browse/JDK-8322142): JFR: Periodic tasks aren't orphaned between recordings (**Bug** - P2)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/31/head:pull/31` \
`$ git checkout pull/31`

Update a local copy of the PR: \
`$ git checkout pull/31` \
`$ git pull https://git.openjdk.org/jdk22.git pull/31/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31`

View PR using the GUI difftool: \
`$ git pr show -t 31`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/31.diff">https://git.openjdk.org/jdk22/pull/31.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/31#issuecomment-1877592810)