### PR TITLE
8322725: (tz) Update Timezone Data to 2023d

### DIFF
--- a/src/java.base/share/data/tzdata/VERSION
+++ b/src/java.base/share/data/tzdata/VERSION
@@ -21,4 +21,4 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-tzdata2023c
+tzdata2023d

--- a/src/java.base/share/data/tzdata/africa
+++ b/src/java.base/share/data/tzdata/africa
@@ -308,13 +308,6 @@ Rule	Egypt	2007	only	-	Sep	Thu>=1	24:00	0	-
 # reproduced by other (more accessible) sites[, e.g.,]...
 # http://elgornal.net/news/news.aspx?id=4699258
 
-# From Paul Eggert (2014-06-04):
-# Sarah El Deeb and Lee Keath of AP report that the Egyptian government says
-# the change is because of blackouts in Cairo, even though Ahram Online (cited
-# above) says DST had no affect on electricity consumption.  There is
-# no information about when DST will end this fall.  See:
-# http://abcnews.go.com/International/wireStory/el-sissi-pushes-egyptians-line-23614833
-
 # From Steffen Thorsen (2015-04-08):
 # Egypt will start DST on midnight after Thursday, April 30, 2015.
 # This is based on a law (no 35) from May 15, 2014 saying it starts the last

--- a/src/java.base/share/data/tzdata/antarctica
+++ b/src/java.base/share/data/tzdata/antarctica
@@ -103,6 +103,11 @@
 # - 2018 Oct  7 4:00 - 2019 Mar 17 3:00 - 2019 Oct  4 3:00 - 2020 Mar  8 3:00
 # and now - 2020 Oct  4 0:01
 
+# From Paul Eggert (2023-12-20):
+# Transitions from 2021 on are taken from:
+# https://www.timeanddate.com/time/zone/antarctica/casey
+# retrieved at various dates.
+
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Antarctica/Casey	 0	-	-00	1969
 			 8:00	-	+08	2009 Oct 18  2:00
@@ -116,7 +121,12 @@ Zone Antarctica/Casey	 0	-	-00	1969
 			 8:00	-	+08	2019 Oct  4  3:00
 			11:00	-	+11	2020 Mar  8  3:00
 			 8:00	-	+08	2020 Oct  4  0:01
-			11:00	-	+11
+			11:00	-	+11	2021 Mar 14  0:00
+			 8:00	-	+08	2021 Oct  3  0:01
+			11:00	-	+11	2022 Mar 13  0:00
+			 8:00	-	+08	2022 Oct  2  0:01
+			11:00	-	+11	2023 Mar  9  3:00
+			 8:00	-	+08
 Zone Antarctica/Davis	0	-	-00	1957 Jan 13
 			7:00	-	+07	1964 Nov
 			0	-	-00	1969 Feb
@@ -263,7 +273,50 @@ Zone Antarctica/Troll	0	-	-00	2005 Feb 12
 #	year-round from 1960/61 to 1992
 
 # Vostok, since 1957-12-16, temporarily closed 1994-02/1994-11
-# See Asia/Urumqi.
+# From Craig Mundell (1994-12-15):
+# http://quest.arc.nasa.gov/antarctica/QA/computers/Directions,Time,ZIP
+# Vostok, which is one of the Russian stations, is set on the same
+# time as Moscow, Russia.
+#
+# From Lee Hotz (2001-03-08):
+# I queried the folks at Columbia who spent the summer at Vostok and this is
+# what they had to say about time there:
+# "in the US Camp (East Camp) we have been on New Zealand (McMurdo)
+# time, which is 12 hours ahead of GMT. The Russian Station Vostok was
+# 6 hours behind that (although only 2 miles away, i.e. 6 hours ahead
+# of GMT). This is a time zone I think two hours east of Moscow. The
+# natural time zone is in between the two: 8 hours ahead of GMT."
+#
+# From Paul Eggert (2001-05-04):
+# This seems to be hopelessly confusing, so I asked Lee Hotz about it
+# in person.  He said that some Antarctic locations set their local
+# time so that noon is the warmest part of the day, and that this
+# changes during the year and does not necessarily correspond to mean
+# solar noon.  So the Vostok time might have been whatever the clocks
+# happened to be during their visit.  So we still don't really know what time
+# it is at Vostok.
+#
+# From Zakhary V. Akulov (2023-12-17 22:00:48 +0700):
+# ... from December, 18, 2023 00:00 by my decision the local time of
+# the Antarctic research base Vostok will correspond to UTC+5.
+# (2023-12-19): We constantly interact with Progress base, with company who
+# builds new wintering station, with sledge convoys, with aviation - they all
+# use UTC+5. Besides, difference between Moscow time is just 2 hours now, not 4.
+# (2023-12-19, in response to the question "Has local time at Vostok
+# been UTC+6 ever since 1957, or has it changed before?"): No. At least
+# since my antarctic career start, 10 years ago, Vostok base has UTC+7.
+# (In response to a 2023-12-18 question "from 02:00 to 00:00 today"): This.
+#
+# From Paul Eggert (2023-12-18):
+# For lack of better info, guess Vostok was at +07 from founding through today,
+# except when closed.
+
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+Zone Antarctica/Vostok	0	-	-00	1957 Dec 16
+			7:00	-	+07	1994 Feb
+			0	-	-00	1994 Nov
+			7:00	-	+07	2023 Dec 18  2:00
+			5:00	-	+05
 
 # S Africa - year-round bases
 # Marion Island, -4653+03752

--- a/src/java.base/share/data/tzdata/asia
+++ b/src/java.base/share/data/tzdata/asia
@@ -678,7 +678,6 @@ Zone	Asia/Shanghai	8:05:43	-	LMT	1901
 			8:00	PRC	C%sT
 # Xinjiang time, used by many in western China; represented by Ürümqi / Ürümchi
 # / Wulumuqi.  (Please use Asia/Shanghai if you prefer Beijing time.)
-# Vostok base in Antarctica matches this since 1970.
 Zone	Asia/Urumqi	5:50:20	-	LMT	1928
 			6:00	-	+06
 
@@ -3450,6 +3449,9 @@ Zone	Asia/Karachi	4:28:12 -	LMT	1907
 # From Heba Hamad (2023-03-22):
 # ... summer time will begin in Palestine from Saturday 04-29-2023,
 # 02:00 AM by 60 minutes forward.
+# From Heba Hemad (2023-10-09):
+# ... winter time will begin in Palestine from Saturday 10-28-2023,
+# 02:00 AM by 60 minutes back.
 #
 # From Paul Eggert (2023-03-22):
 # For now, guess that spring and fall transitions will normally
@@ -3571,13 +3573,13 @@ Rule Palestine	2070	only	-	Oct	 4	2:00	0	-
 Rule Palestine	2071	only	-	Sep	19	2:00	0	-
 Rule Palestine	2072	only	-	Sep	10	2:00	0	-
 Rule Palestine	2072	only	-	Oct	15	2:00	1:00	S
+Rule Palestine	2072	max	-	Oct	Sat<=30	2:00	0	-
 Rule Palestine	2073	only	-	Sep	 2	2:00	0	-
 Rule Palestine	2073	only	-	Oct	 7	2:00	1:00	S
 Rule Palestine	2074	only	-	Aug	18	2:00	0	-
 Rule Palestine	2074	only	-	Sep	29	2:00	1:00	S
 Rule Palestine	2075	only	-	Aug	10	2:00	0	-
 Rule Palestine	2075	only	-	Sep	14	2:00	1:00	S
-Rule Palestine	2075	max	-	Oct	Sat<=30	2:00	0	-
 Rule Palestine	2076	only	-	Jul	25	2:00	0	-
 Rule Palestine	2076	only	-	Sep	 5	2:00	1:00	S
 Rule Palestine	2077	only	-	Jul	17	2:00	0	-

--- a/src/java.base/share/data/tzdata/australasia
+++ b/src/java.base/share/data/tzdata/australasia
@@ -414,8 +414,14 @@ Zone Antarctica/Macquarie 0	-	-00	1899 Nov
 # Please note that there will not be any daylight savings time change
 # in Fiji for 2022-2023....
 # https://www.facebook.com/FijianGovernment/posts/pfbid0mmWVTYmTibn66ybpFda75pDcf34SSpoSaskJW5gXwaKo5Sgc7273Q4fXWc6kQV6Hl
+
+# From Almaz Mingaleev (2023-10-06):
+# Cabinet approved the suspension of Daylight Saving and appropriate
+# legislative changes will be considered including the repeal of the
+# Daylight Saving Act 1998
+# https://www.fiji.gov.fj/Media-Centre/Speeches/English/CABINET-DECISIONS-3-OCTOBER-2023
 #
-# From Paul Eggert (2022-10-27):
+# From Paul Eggert (2023-10-06):
 # For now, assume DST is suspended indefinitely.
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S

--- a/src/java.base/share/data/tzdata/backward
+++ b/src/java.base/share/data/tzdata/backward
@@ -228,7 +228,6 @@ Link	America/Puerto_Rico	America/Tortola
 Link	Pacific/Port_Moresby	Antarctica/DumontDUrville
 Link	Pacific/Auckland	Antarctica/McMurdo
 Link	Asia/Riyadh		Antarctica/Syowa
-Link	Asia/Urumqi		Antarctica/Vostok
 Link	Europe/Berlin		Arctic/Longyearbyen
 Link	Asia/Riyadh		Asia/Aden
 Link	Asia/Qatar		Asia/Bahrain

--- a/src/java.base/share/data/tzdata/europe
+++ b/src/java.base/share/data/tzdata/europe
@@ -1146,6 +1146,23 @@ Zone Atlantic/Faroe	-0:27:04 -	LMT	1908 Jan 11 # Tórshavn
 # 2. The shift *from* DST in 2023 happens as normal, but coincides with the
 #    shift to UTC-02 normaltime (people will not change their clocks here).
 # 3. After this, DST is still observed, but as -02/-01 instead of -03/-02.
+#
+# From Múte Bourup Egede via Jógvan Svabo Samuelsen (2023-03-15):
+# Greenland will not switch to Daylight Saving Time this year, 2023,
+# because the standard time for Greenland will change from UTC -3 to UTC -2.
+# However, Greenland will change to Daylight Saving Time again in 2024
+# and onwards.
+
+# From a contributor who wishes to remain anonymous for now (2023-10-29):
+# https://www.dr.dk/nyheder/seneste/i-nat-skal-uret-stilles-en-time-tilbage-men-foerste-gang-sker-det-ikke-i-groenland
+# with a link to that page:
+# https://naalakkersuisut.gl/Nyheder/2023/10/2710_sommertid
+# ... Ittoqqortoormiit joins the time of Nuuk at March 2024.
+# What would mean that America/Scoresbysund would either be in -01 year round
+# or in -02/-01 like America/Nuuk, but no longer in -01/+00.
+#
+# From Paul Eggert (2023-10-29):
+# For now, assume it will be like America/Nuuk.
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Thule	1991	1992	-	Mar	lastSun	2:00	1:00	D
@@ -1166,10 +1183,12 @@ Zone America/Danmarkshavn -1:14:40 -	LMT	1916 Jul 28
 Zone America/Scoresbysund -1:27:52 -	LMT	1916 Jul 28 # Ittoqqortoormiit
 			-2:00	-	-02	1980 Apr  6  2:00
 			-2:00	C-Eur	-02/-01	1981 Mar 29
-			-1:00	EU	-01/+00
+			-1:00	EU	-01/+00 2024 Mar 31
+			-2:00	EU	-02/-01
 Zone America/Nuuk	-3:26:56 -	LMT	1916 Jul 28 # Godthåb
 			-3:00	-	-03	1980 Apr  6  2:00
-			-3:00	EU	-03/-02	2023 Oct 29  1:00u
+			-3:00	EU	-03/-02	2023 Mar 26  1:00u
+			-2:00	-	-02	2023 Oct 29  1:00u
 			-2:00	EU	-02/-01
 Zone America/Thule	-4:35:08 -	LMT	1916 Jul 28 # Pituffik
 			-4:00	Thule	A%sT
@@ -3734,11 +3753,7 @@ Zone	Europe/Istanbul	1:55:52 -	LMT	1880
 # and not at 3:00 as would have been under EU rules.
 # This is why I have set the change to EU rules into May 1996,
 # so that the change in March is stil covered by the Ukraine rule.
-# The next change in October 1996 happened under EU rules....
-# TZ database holds three other zones for Ukraine.... I have not yet
-# worked out the consequences for these three zones, as we (me and my
-# US colleague David Cochrane) are still trying to get more
-# information upon these local deviations from Kiev rules.
+# The next change in October 1996 happened under EU rules.
 #
 # From Paul Eggert (2022-08-27):
 # For now, assume that Ukraine's zones all followed the same rules,

--- a/src/java.base/share/data/tzdata/iso3166.tab
+++ b/src/java.base/share/data/tzdata/iso3166.tab
@@ -26,17 +26,22 @@
 # This file is in the public domain, so clarified as of
 # 2009-05-17 by Arthur David Olson.
 #
-# From Paul Eggert (2022-11-18):
+# From Paul Eggert (2023-09-06):
 # This file contains a table of two-letter country codes.  Columns are
 # separated by a single tab.  Lines beginning with '#' are comments.
 # All text uses UTF-8 encoding.  The columns of the table are as follows:
 #
 # 1.  ISO 3166-1 alpha-2 country code, current as of
-#     ISO 3166-1 N1087 (2022-09-02).  See: Updates on ISO 3166-1
-#     https://isotc.iso.org/livelink/livelink/Open/16944257
-# 2.  The usual English name for the coded region,
-#     chosen so that alphabetic sorting of subsets produces helpful lists.
-#     This is not the same as the English name in the ISO 3166 tables.
+#     ISO/TC 46 N1108 (2023-04-05).  See: ISO/TC 46 Documents
+#     https://www.iso.org/committee/48750.html?view=documents
+# 2.  The usual English name for the coded region.  This sometimes
+#     departs from ISO-listed names, sometimes so that sorted subsets
+#     of names are useful (e.g., "Samoa (American)" and "Samoa
+#     (western)" rather than "American Samoa" and "Samoa"),
+#     sometimes to avoid confusion among non-experts (e.g.,
+#     "Czech Republic" and "Turkey" rather than "Czechia" and "Türkiye"),
+#     and sometimes to omit needless detail or churn (e.g., "Netherlands"
+#     rather than "Netherlands (the)" or "Netherlands (Kingdom of the)").
 #
 # The table is sorted by country code.
 #

--- a/src/java.base/share/data/tzdata/leapseconds
+++ b/src/java.base/share/data/tzdata/leapseconds
@@ -95,11 +95,11 @@ Leap	2016	Dec	31	23:59:60	+	S
 # Any additional leap seconds will come after this.
 # This Expires line is commented out for now,
 # so that pre-2020a zic implementations do not reject this file.
-#Expires 2023	Dec	28	00:00:00
+#Expires 2024	Jun	28	00:00:00
 
 # POSIX timestamps for the data in this file:
 #updated 1467936000 (2016-07-08 00:00:00 UTC)
-#expires 1703721600 (2023-12-28 00:00:00 UTC)
+#expires 1719532800 (2024-06-28 00:00:00 UTC)
 
-#	Updated through IERS Bulletin C65
-#	File expires on:  28 December 2023
+#	Updated through IERS Bulletin C66
+#	File expires on:  28 June 2024

--- a/src/java.base/share/data/tzdata/northamerica
+++ b/src/java.base/share/data/tzdata/northamerica
@@ -1,3 +1,4 @@
+#
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -1475,7 +1476,7 @@ Rule	StJohns	1989	2006	-	Apr	Sun>=1	0:01	1:00	D
 Rule	StJohns	2007	2011	-	Mar	Sun>=8	0:01	1:00	D
 Rule	StJohns	2007	2010	-	Nov	Sun>=1	0:01	0	S
 #
-# St John's has an apostrophe, but Posix file names can't have apostrophes.
+# St John's has an apostrophe, but POSIX file names can't have apostrophes.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/St_Johns	-3:30:52 -	LMT	1884
 			-3:30:52 StJohns N%sT	1918

--- a/src/java.base/share/data/tzdata/southamerica
+++ b/src/java.base/share/data/tzdata/southamerica
@@ -1720,6 +1720,12 @@ Rule	Para	2010	2012	-	Apr	Sun>=8	0:00	0	-
 # From Carlos Raúl Perasso (2014-02-28):
 # Decree 1264 can be found at:
 # http://www.presidencia.gov.py/archivos/documentos/DECRETO1264_ey9r8zai.pdf
+#
+# From Paul Eggert (2023-07-26):
+# Transition dates are now set by Law No. 7115, not by presidential decree.
+# https://www.abc.com.py/politica/2023/07/12/promulgacion-el-cambio-de-hora-sera-por-ley/
+# From Carlos Raúl Perasso (2023-07-27):
+# http://silpy.congreso.gov.py/descarga/ley-144138
 Rule	Para	2013	max	-	Mar	Sun>=22	0:00	0	-
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]

--- a/src/java.base/share/data/tzdata/zone.tab
+++ b/src/java.base/share/data/tzdata/zone.tab
@@ -71,7 +71,7 @@ AR	-3124-06411	America/Argentina/Cordoba	Argentina (most areas: CB, CC, CN, ER, 
 AR	-2447-06525	America/Argentina/Salta	Salta (SA, LP, NQ, RN)
 AR	-2411-06518	America/Argentina/Jujuy	Jujuy (JY)
 AR	-2649-06513	America/Argentina/Tucuman	Tucuman (TM)
-AR	-2828-06547	America/Argentina/Catamarca	Catamarca (CT); Chubut (CH)
+AR	-2828-06547	America/Argentina/Catamarca	Catamarca (CT), Chubut (CH)
 AR	-2926-06651	America/Argentina/La_Rioja	La Rioja (LR)
 AR	-3132-06831	America/Argentina/San_Juan	San Juan (SJ)
 AR	-3253-06849	America/Argentina/Mendoza	Mendoza (MZ)
@@ -110,7 +110,7 @@ BN	+0456+11455	Asia/Brunei
 BO	-1630-06809	America/La_Paz
 BQ	+120903-0681636	America/Kralendijk
 BR	-0351-03225	America/Noronha	Atlantic islands
-BR	-0127-04829	America/Belem	Para (east); Amapa
+BR	-0127-04829	America/Belem	Para (east), Amapa
 BR	-0343-03830	America/Fortaleza	Brazil (northeast: MA, PI, CE, RN, PB)
 BR	-0803-03454	America/Recife	Pernambuco
 BR	-0712-04812	America/Araguaina	Tocantins
@@ -130,21 +130,21 @@ BT	+2728+08939	Asia/Thimphu
 BW	-2439+02555	Africa/Gaborone
 BY	+5354+02734	Europe/Minsk
 BZ	+1730-08812	America/Belize
-CA	+4734-05243	America/St_Johns	Newfoundland; Labrador (southeast)
-CA	+4439-06336	America/Halifax	Atlantic - NS (most areas); PE
+CA	+4734-05243	America/St_Johns	Newfoundland, Labrador (SE)
+CA	+4439-06336	America/Halifax	Atlantic - NS (most areas), PE
 CA	+4612-05957	America/Glace_Bay	Atlantic - NS (Cape Breton)
 CA	+4606-06447	America/Moncton	Atlantic - New Brunswick
 CA	+5320-06025	America/Goose_Bay	Atlantic - Labrador (most areas)
 CA	+5125-05707	America/Blanc-Sablon	AST - QC (Lower North Shore)
-CA	+4339-07923	America/Toronto	Eastern - ON, QC (most areas)
+CA	+4339-07923	America/Toronto	Eastern - ON & QC (most areas)
 CA	+6344-06828	America/Iqaluit	Eastern - NU (most areas)
-CA	+484531-0913718	America/Atikokan	EST - ON (Atikokan); NU (Coral H)
-CA	+4953-09709	America/Winnipeg	Central - ON (west); Manitoba
+CA	+484531-0913718	America/Atikokan	EST - ON (Atikokan), NU (Coral H)
+CA	+4953-09709	America/Winnipeg	Central - ON (west), Manitoba
 CA	+744144-0944945	America/Resolute	Central - NU (Resolute)
 CA	+624900-0920459	America/Rankin_Inlet	Central - NU (central)
 CA	+5024-10439	America/Regina	CST - SK (most areas)
 CA	+5017-10750	America/Swift_Current	CST - SK (midwest)
-CA	+5333-11328	America/Edmonton	Mountain - AB; BC (E); NT (E); SK (W)
+CA	+5333-11328	America/Edmonton	Mountain - AB, BC(E), NT(E), SK(W)
 CA	+690650-1050310	America/Cambridge_Bay	Mountain - NU (west)
 CA	+682059-1334300	America/Inuvik	Mountain - NT (west)
 CA	+4906-11631	America/Creston	MST - BC (Creston)
@@ -230,8 +230,8 @@ HT	+1832-07220	America/Port-au-Prince
 HU	+4730+01905	Europe/Budapest
 ID	-0610+10648	Asia/Jakarta	Java, Sumatra
 ID	-0002+10920	Asia/Pontianak	Borneo (west, central)
-ID	-0507+11924	Asia/Makassar	Borneo (east, south); Sulawesi/Celebes, Bali, Nusa Tengarra; Timor (west)
-ID	-0232+14042	Asia/Jayapura	New Guinea (West Papua / Irian Jaya); Malukus/Moluccas
+ID	-0507+11924	Asia/Makassar	Borneo (east, south), Sulawesi/Celebes, Bali, Nusa Tengarra, Timor (west)
+ID	-0232+14042	Asia/Jayapura	New Guinea (West Papua / Irian Jaya), Malukus/Moluccas
 IE	+5320-00615	Europe/Dublin
 IL	+314650+0351326	Asia/Jerusalem
 IM	+5409-00428	Europe/Isle_of_Man
@@ -378,7 +378,7 @@ RU	+4310+13156	Asia/Vladivostok	MSK+07 - Amur River
 RU	+643337+1431336	Asia/Ust-Nera	MSK+07 - Oymyakonsky
 RU	+5934+15048	Asia/Magadan	MSK+08 - Magadan
 RU	+4658+14242	Asia/Sakhalin	MSK+08 - Sakhalin Island
-RU	+6728+15343	Asia/Srednekolymsk	MSK+08 - Sakha (E); N Kuril Is
+RU	+6728+15343	Asia/Srednekolymsk	MSK+08 - Sakha (E), N Kuril Is
 RU	+5301+15839	Asia/Kamchatka	MSK+09 - Kamchatka
 RU	+6445+17729	Asia/Anadyr	MSK+09 - Bering Sea
 RW	-0157+03004	Africa/Kigali
@@ -441,7 +441,7 @@ US	+470659-1011757	America/North_Dakota/Center	Central - ND (Oliver)
 US	+465042-1012439	America/North_Dakota/New_Salem	Central - ND (Morton rural)
 US	+471551-1014640	America/North_Dakota/Beulah	Central - ND (Mercer)
 US	+394421-1045903	America/Denver	Mountain (most areas)
-US	+433649-1161209	America/Boise	Mountain - ID (south); OR (east)
+US	+433649-1161209	America/Boise	Mountain - ID (south), OR (east)
 US	+332654-1120424	America/Phoenix	MST - AZ (except Navajo)
 US	+340308-1181434	America/Los_Angeles	Pacific
 US	+611305-1495401	America/Anchorage	Alaska (most areas)

--- a/test/jdk/java/util/TimeZone/TimeZoneData/VERSION
+++ b/test/jdk/java/util/TimeZone/TimeZoneData/VERSION
@@ -1,1 +1,1 @@
-tzdata2023c
+tzdata2023d

--- a/test/jdk/java/util/TimeZone/TimeZoneData/aliases.txt
+++ b/test/jdk/java/util/TimeZone/TimeZoneData/aliases.txt
@@ -148,7 +148,6 @@ Link	America/Puerto_Rico	America/Tortola
 Link	Pacific/Port_Moresby	Antarctica/DumontDUrville
 Link	Pacific/Auckland	Antarctica/McMurdo
 Link	Asia/Riyadh		Antarctica/Syowa
-Link	Asia/Urumqi		Antarctica/Vostok
 Link	Europe/Berlin		Arctic/Longyearbyen
 Link	Asia/Riyadh		Asia/Aden
 Link	Asia/Qatar		Asia/Bahrain


### PR DESCRIPTION
Backport tzdata2023d

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322725](https://bugs.openjdk.org/browse/JDK-8322725): (tz) Update Timezone Data to 2023d (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/34/head:pull/34` \
`$ git checkout pull/34`

Update a local copy of the PR: \
`$ git checkout pull/34` \
`$ git pull https://git.openjdk.org/jdk22.git pull/34/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 34`

View PR using the GUI difftool: \
`$ git pr show -t 34`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/34.diff">https://git.openjdk.org/jdk22/pull/34.diff</a>

</details>
