### PR TITLE
8321683: Tests fail with AssertionError in RangeWithPageSize

### DIFF
--- a/test/hotspot/jtreg/runtime/os/TestTracePageSizes.java
+++ b/test/hotspot/jtreg/runtime/os/TestTracePageSizes.java
@@ -350,7 +350,7 @@ class RangeWithPageSize {
         this.start = Long.parseUnsignedLong(start, 16);
         this.end = Long.parseUnsignedLong(end, 16);
         this.pageSize = Long.parseLong(pageSize);
-        this.thpEligible = Integer.parseInt(thpEligible) == 1;
+        this.thpEligible = thpEligible == null ? false : (Integer.parseInt(thpEligible) == 1);
 
         vmFlagHG = false;
         vmFlagHT = false;
@@ -365,12 +365,11 @@ class RangeWithPageSize {
             }
         }
 
-        // When the THP policy is 'always' instead of 'madvise, the vmFlagHG property is false.
-        // Check the THPeligible property instead.
-        isTHP = !vmFlagHT && this.thpEligible;
+        // When the THP policy is 'always' instead of 'madvise, the vmFlagHG property is false,
+        // therefore also check thpEligible. If this is still causing problems in the future,
+        // we might have to check the AnonHugePages field.
 
-        // vmFlagHG should imply isTHP
-        assert !vmFlagHG || isTHP;
+        isTHP = vmFlagHG || this.thpEligible;
     }
 
     public long getPageSize() {


### PR DESCRIPTION
Hi all,

    This pull request contains a backport of commit [dce7a573](https://github.com/openjdk/jdk/commit/dce7a5732e69b6d29f75b98f6cf58a567d353a59) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

    The commit being backported was authored by Stefan Karlsson on 22 Dec 2023 and was reviewed by Thomas Stuefe and Matthias Baesken.

    Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321683](https://bugs.openjdk.org/browse/JDK-8321683): Tests fail with AssertionError in RangeWithPageSize (**Bug** - P4)


### Reviewers
 * [Erik Duveblad](https://openjdk.org/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/37/head:pull/37` \
`$ git checkout pull/37`

Update a local copy of the PR: \
`$ git checkout pull/37` \
`$ git pull https://git.openjdk.org/jdk22.git pull/37/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 37`

View PR using the GUI difftool: \
`$ git pr show -t 37`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/37.diff">https://git.openjdk.org/jdk22/pull/37.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/37#issuecomment-1880654490)