### PR TITLE
8322489: 22-b27: Up to 7% regression in all Footprint3-*-G1/ZGC

### DIFF
--- a/src/hotspot/share/jfr/jfr.cpp
+++ b/src/hotspot/share/jfr/jfr.cpp
@@ -67,7 +67,9 @@ void Jfr::on_create_vm_3() {
 }
 
 void Jfr::on_unloading_classes() {
-  JfrCheckpointManager::on_unloading_classes();
+  if (JfrRecorder::is_created() || JfrRecorder::is_started_on_commandline()) {
+    JfrCheckpointManager::on_unloading_classes();
+  }
 }
 
 bool Jfr::is_excluded(Thread* t) {

--- a/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.cpp
@@ -117,16 +117,16 @@ bool JfrCheckpointManager::initialize_early() {
   assert(_thread_local_mspace == nullptr, "invariant");
   _thread_local_mspace = new JfrThreadLocalCheckpointMspace();
   if (_thread_local_mspace == nullptr || !_thread_local_mspace->initialize(thread_local_buffer_size,
-                                                                        thread_local_buffer_prealloc_count,
-                                                                        thread_local_buffer_prealloc_count)) {
+                                                                           thread_local_buffer_prealloc_count,
+                                                                           thread_local_buffer_prealloc_count)) {
     return false;
   }
 
   assert(_virtual_thread_local_mspace == nullptr, "invariant");
   _virtual_thread_local_mspace = new JfrThreadLocalCheckpointMspace();
   if (_virtual_thread_local_mspace == nullptr || !_virtual_thread_local_mspace->initialize(virtual_thread_local_buffer_size,
-                                                                                        JFR_MSPACE_UNLIMITED_CACHE_SIZE,
-                                                                                        virtual_thread_local_buffer_prealloc_count)) {
+                                                                                           JFR_MSPACE_UNLIMITED_CACHE_SIZE,
+                                                                                           virtual_thread_local_buffer_prealloc_count)) {
     return false;
   }
   return true;

--- a/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointWriter.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointWriter.hpp
@@ -55,6 +55,7 @@ struct JfrCheckpointContext {
 
 class JfrCheckpointWriter : public JfrCheckpointWriterBase {
   friend class JfrCheckpointManager;
+  friend class JfrDeprecationManager;
   friend class JfrSerializerRegistration;
   friend class JfrTypeManager;
  private:

--- a/src/hotspot/share/jfr/recorder/jfrRecorder.hpp
+++ b/src/hotspot/share/jfr/recorder/jfrRecorder.hpp
@@ -42,6 +42,7 @@ class JfrRecorder : public JfrCHeapObj {
   static bool on_create_vm_2();
   static bool on_create_vm_3();
   static bool create_checkpoint_manager();
+  static bool initialize_checkpoint_manager();
   static bool create_chunk_repository();
   static bool create_java_event_writer();
   static bool create_jvmti_agent();

--- a/src/hotspot/share/jfr/support/jfrDeprecationManager.cpp
+++ b/src/hotspot/share/jfr/support/jfrDeprecationManager.cpp
@@ -371,8 +371,10 @@ void JfrDeprecationManager::write_edges(JfrChunkWriter& cw, Thread* thread, bool
 
 void JfrDeprecationManager::on_type_set(JfrCheckpointWriter& writer, JfrChunkWriter* cw, Thread* thread) {
   assert(_pending_list.is_empty(), "invariant");
-  if (writer.has_data() && _pending_head != nullptr) {
+  if (_pending_head != nullptr) {
     save_type_set_blob(writer);
+  } else {
+    writer.cancel();
   }
   if (cw != nullptr) {
     write_edges(*cw, thread);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322489](https://bugs.openjdk.org/browse/JDK-8322489): 22-b27: Up to 7% regression in all Footprint3-*-G1/ZGC (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/39/head:pull/39` \
`$ git checkout pull/39`

Update a local copy of the PR: \
`$ git checkout pull/39` \
`$ git pull https://git.openjdk.org/jdk22.git pull/39/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 39`

View PR using the GUI difftool: \
`$ git pr show -t 39`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/39.diff">https://git.openjdk.org/jdk22/pull/39.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/39#issuecomment-1880859269)