### PR TITLE
8322003: JShell - Incorrect type inference in lists of records implementing interfaces

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -967,6 +967,20 @@ public class JavacParser implements Parser {
         return result;
     }
 
+    protected JCExpression parseIntersectionType(int pos, JCExpression firstType) {
+        JCExpression t = firstType;
+        int pos1 = pos;
+        List<JCExpression> targets = List.of(t);
+        while (token.kind == AMP) {
+            accept(AMP);
+            targets = targets.prepend(parseType());
+        }
+        if (targets.length() > 1) {
+            t = toP(F.at(pos1).TypeIntersection(targets.reverse()));
+        }
+        return t;
+    }
+
     public JCExpression unannotatedType(boolean allowVar) {
         return unannotatedType(allowVar, TYPE);
     }
@@ -1337,15 +1351,7 @@ public class JavacParser implements Parser {
                     case CAST:
                        accept(LPAREN);
                        selectTypeMode();
-                       int pos1 = pos;
-                       List<JCExpression> targets = List.of(t = parseType());
-                       while (token.kind == AMP) {
-                           accept(AMP);
-                           targets = targets.prepend(parseType());
-                       }
-                       if (targets.length() > 1) {
-                           t = toP(F.at(pos1).TypeIntersection(targets.reverse()));
-                       }
+                       t = parseIntersectionType(pos, parseType());
                        accept(RPAREN);
                        selectExprMode();
                        JCExpression t1 = term3();

--- a/test/langtools/jdk/jshell/VariablesTest.java
+++ b/test/langtools/jdk/jshell/VariablesTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8144903 8177466 8191842 8211694 8213725 8239536 8257236 8252409 8294431 8322532
+ * @bug 8144903 8177466 8191842 8211694 8213725 8239536 8257236 8252409 8294431 8322003 8322532
  * @summary Tests for EvaluationState.variables
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -625,6 +625,17 @@ public class VariablesTest extends KullaTesting {
         assertAnalyze("Func f = _ -> 0; int i;",
                       "Func f = _ -> 0;",
                       " int i;", true);
+    }
+
+    public void intersectionTypeAsTypeArgument() { //JDK-8322003
+        assertEval("interface Shape {}");
+        assertEval("record Square(int edge) implements Shape {}");
+        assertEval("record Circle(int radius) implements Shape {}");
+        assertEval("java.util.function.Consumer<Shape> printShape = System.out::println;");
+        assertEval("Square square = new Square(1);");
+        assertEval("Circle circle = new Circle(1);");
+        assertEval("var shapes = java.util.List.of(square, circle);");
+        assertEval("shapes.forEach(printShape);");
     }
 
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [57a65fe4](https://github.com/openjdk/jdk/commit/57a65fe436a3617d64bbf0b02d4c7f7c2551448f) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jan Lahoda on 8 Jan 2024 and was reviewed by Vicente Romero.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322003](https://bugs.openjdk.org/browse/JDK-8322003): JShell - Incorrect type inference in lists of records implementing interfaces (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/40/head:pull/40` \
`$ git checkout pull/40`

Update a local copy of the PR: \
`$ git checkout pull/40` \
`$ git pull https://git.openjdk.org/jdk22.git pull/40/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 40`

View PR using the GUI difftool: \
`$ git pr show -t 40`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/40.diff">https://git.openjdk.org/jdk22/pull/40.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/40#issuecomment-1881116492)