### PR TITLE
8322163: runtime/Unsafe/InternalErrorTest.java fails on Alpine after JDK-8320886

### DIFF
--- a/src/hotspot/share/utilities/copy.cpp
+++ b/src/hotspot/share/utilities/copy.cpp
@@ -243,6 +243,16 @@ void Copy::fill_to_memory_atomic(void* to, size_t size, jubyte value) {
     }
   } else {
     // Not aligned, so no need to be atomic.
+#ifdef MUSL_LIBC
+    // This code is used by Unsafe and may hit the next page after truncation of mapped memory.
+    // Therefore, we use volatile to prevent compilers from replacing the loop by memset which
+    // may not trigger SIGBUS as needed (observed on Alpine Linux x86_64)
+    jbyte fill = value;
+    for (uintptr_t off = 0; off < size; off += sizeof(jbyte)) {
+      *(volatile jbyte*)(dst + off) = fill;
+    }
+#else
     Copy::fill_to_bytes(dst, size, value);
+#endif
   }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8322163](https://bugs.openjdk.org/browse/JDK-8322163), commit [12308533](https://github.com/openjdk/jdk/commit/1230853343c38787c90820d19d0626f0c37540dc) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Matthias Baesken on 22 Dec 2023 and was reviewed by Martin Doerr and Christoph Langer.

The bug is P3 and hence appropriate for RDP1. It quieces a test error that we see regularly on Alpine.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322163](https://bugs.openjdk.org/browse/JDK-8322163): runtime/Unsafe/InternalErrorTest.java fails on Alpine after JDK-8320886 (**Bug** - P3)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/43/head:pull/43` \
`$ git checkout pull/43`

Update a local copy of the PR: \
`$ git checkout pull/43` \
`$ git pull https://git.openjdk.org/jdk22.git pull/43/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 43`

View PR using the GUI difftool: \
`$ git pr show -t 43`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/43.diff">https://git.openjdk.org/jdk22/pull/43.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/43#issuecomment-1883520014)