### PR TITLE
8323547: tools/jlink/plugins/SystemModuleDescriptors/ModuleMainClassTest.java fails to compile

### DIFF
--- a/test/jdk/tools/jlink/plugins/SystemModuleDescriptors/ModuleMainClassTest.java
+++ b/test/jdk/tools/jlink/plugins/SystemModuleDescriptors/ModuleMainClassTest.java
@@ -102,7 +102,7 @@ public class ModuleMainClassTest {
     }
 
     @Test
-    public void testComFoo() throws Exception {
+    public void testComFoo() throws Throwable {
         if (!hasJmods()) return;
 
         Path java = IMAGE.resolve("bin").resolve("java");
@@ -114,7 +114,7 @@ public class ModuleMainClassTest {
     }
 
     @Test
-    public void testNetFoo() throws Exception {
+    public void testNetFoo() throws Throwable {
         if (!hasJmods()) return;
 
         Path java = IMAGE.resolve("bin").resolve("java");


### PR DESCRIPTION
`jdk.test.lib.process.ProcessTools::executeTools` was modified to throw Exception by JDK-8322920 that has only been in the main line.   It's a mistake to backport JDK-8322809 without catching this.   Trivial fix - update the signature to throw Throwable instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323547](https://bugs.openjdk.org/browse/JDK-8323547): tools/jlink/plugins/SystemModuleDescriptors/ModuleMainClassTest.java fails to compile (**Bug** - P1)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/58/head:pull/58` \
`$ git checkout pull/58`

Update a local copy of the PR: \
`$ git checkout pull/58` \
`$ git pull https://git.openjdk.org/jdk22.git pull/58/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 58`

View PR using the GUI difftool: \
`$ git pr show -t 58`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/58.diff">https://git.openjdk.org/jdk22/pull/58.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/58#issuecomment-1885706711)