### PR TITLE
8320788: The system properties page is missing some properties

### DIFF
--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -57,6 +57,7 @@ import java.security.PrivilegedAction;
 import java.security.ProtectionDomain;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -813,6 +814,10 @@ public final class System {
      * Note that even if the security manager does not permit the
      * {@code getProperties} operation, it may choose to permit the
      * {@link #getProperty(String)} operation.
+     * <p>
+     * Additional locale-related system properties defined by the
+     * {@link Locale##default_locale Default Locale} section in the {@code Locale}
+     * class description may also be obtained with this method.
      *
      * @apiNote
      * <strong>Changing a standard system property may have unpredictable results


### PR DESCRIPTION
Backporting the document only fix to jdk22

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8323347](https://bugs.openjdk.org/browse/JDK-8323347) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8320788](https://bugs.openjdk.org/browse/JDK-8320788): The system properties page is missing some properties (**Bug** - P4)
 * [JDK-8323347](https://bugs.openjdk.org/browse/JDK-8323347): The system properties page is missing some properties (**CSR**)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/59/head:pull/59` \
`$ git checkout pull/59`

Update a local copy of the PR: \
`$ git checkout pull/59` \
`$ git pull https://git.openjdk.org/jdk22.git pull/59/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 59`

View PR using the GUI difftool: \
`$ git pr show -t 59`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/59.diff">https://git.openjdk.org/jdk22/pull/59.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/59#issuecomment-1885725061)