### PR TITLE
8322237: Heap dump contains duplicate thread records for mounted virtual threads

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java
@@ -26,7 +26,9 @@ import java.lang.ref.Reference;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -223,11 +225,22 @@ public class VThreadInHeapDump {
             // Log all threads with stack traces and stack references.
             List<ThreadObject> threads = snapshot.getThreads();
             List<Root> roots = Collections.list(snapshot.getRoots());
+            // And detect thread object duplicates.
+            Set<Long> uniqueThreads = new HashSet<>();
+
             log("Threads:");
             for (ThreadObject thread: threads) {
+                JavaHeapObject threadObj = snapshot.findThing(thread.getId());
+                JavaClass threadClass = threadObj.getClazz();
                 StackTrace st = thread.getStackTrace();
                 StackFrame[] frames = st.getFrames();
-                log("thread " + thread.getIdString() + ", " + frames.length + " frames");
+                log("thread " + thread.getIdString() + " (" + threadClass.getName() + "), " + frames.length + " frames");
+
+                if (uniqueThreads.contains(thread.getId())) {
+                    log(" - ERROR: duplicate");
+                } else {
+                    uniqueThreads.add(thread.getId());
+                }
 
                 List<Root> stackRoots = findStackRoot(roots, thread);
                 for (int i = 0; i < frames.length; i++) {
@@ -248,6 +261,10 @@ public class VThreadInHeapDump {
                         }
                     }
                 }
+            }
+
+            if (threads.size() != uniqueThreads.size()) {
+                throw new RuntimeException("Thread duplicates detected (" + (threads.size() - uniqueThreads.size()) + ")");
             }
 
             // Verify objects from thread stacks are dumped.


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [dd8ae616](https://github.com/openjdk/jdk/commit/dd8ae616437398f957f9b4f09cf2c7f1d0bd0938) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Alex Menkov on 9 Jan 2024 and was reviewed by David Holmes and Serguei Spitsyn.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322237](https://bugs.openjdk.org/browse/JDK-8322237): Heap dump contains duplicate thread records for mounted virtual threads (**Bug** - P3)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/60/head:pull/60` \
`$ git checkout pull/60`

Update a local copy of the PR: \
`$ git checkout pull/60` \
`$ git pull https://git.openjdk.org/jdk22.git pull/60/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 60`

View PR using the GUI difftool: \
`$ git pr show -t 60`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/60.diff">https://git.openjdk.org/jdk22/pull/60.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/60#issuecomment-1886021938)