### PR TITLE
8322513: Build failure with minimal

### DIFF
--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -487,10 +487,12 @@ HandshakeOperation* HandshakeState::get_op_for_self(bool allow_suspend, bool che
   assert(_handshakee == Thread::current(), "Must be called by self");
   assert(_lock.owned_by_self(), "Lock must be held");
   assert(allow_suspend || !check_async_exception, "invalid case");
+#if INCLUDE_JVMTI
   if (allow_suspend && _handshakee->is_disable_suspend()) {
     // filter out suspend operations while JavaThread is in disable_suspend mode
     allow_suspend = false;
   }
+#endif
   if (!allow_suspend) {
     return _queue.peek(no_suspend_no_async_exception_filter);
   } else if (check_async_exception && !_async_exceptions_blocked) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [7db69e6a](https://github.com/openjdk/jdk/commit/7db69e6a1292829b13da0c3c2b37c8758df94932) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by bobpengxie on 20 Dec 2023 and was reviewed by David Holmes and Robbin Ehn.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322513](https://bugs.openjdk.org/browse/JDK-8322513): Build failure with minimal (**Bug** - P3)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/66/head:pull/66` \
`$ git checkout pull/66`

Update a local copy of the PR: \
`$ git checkout pull/66` \
`$ git pull https://git.openjdk.org/jdk22.git pull/66/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 66`

View PR using the GUI difftool: \
`$ git pr show -t 66`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/66.diff">https://git.openjdk.org/jdk22/pull/66.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/66#issuecomment-1888296648)