### PR TITLE
8323159: Consider adding some text re. memory zeroing in Arena::allocate

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Arena.java
+++ b/src/java.base/share/classes/java/lang/foreign/Arena.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -219,6 +219,9 @@ public interface Arena extends SegmentAllocator, AutoCloseable {
      * Segments allocated with the returned arena can be
      * {@linkplain MemorySegment#isAccessibleBy(Thread) accessed} by any thread.
      * Calling {@link #close()} on the returned arena will result in an {@link UnsupportedOperationException}.
+     * <p>
+     * Memory segments {@linkplain #allocate(long, long) allocated} by the returned arena
+     * are zero-initialized.
      *
      * @return a new arena that is managed, automatically, by the garbage collector
      */
@@ -231,6 +234,9 @@ public interface Arena extends SegmentAllocator, AutoCloseable {
      *          {@linkplain MemorySegment#isAccessibleBy(Thread) accessed} by any thread.
      *          Calling {@link #close()} on the returned arena will result in
      *          an {@link UnsupportedOperationException}.
+     * <p>
+     * Memory segments {@linkplain #allocate(long, long) allocated} by the returned arena
+     * are zero-initialized.
      */
     static Arena global() {
         class Holder {
@@ -243,6 +249,9 @@ public interface Arena extends SegmentAllocator, AutoCloseable {
      * {@return a new confined arena} Segments allocated with the confined arena can be
      *          {@linkplain MemorySegment#isAccessibleBy(Thread) accessed} by the thread
      *          that created the arena, the arena's <em>owner thread</em>.
+     * <p>
+     * Memory segments {@linkplain #allocate(long, long) allocated} by the returned arena
+     * are zero-initialized.
      */
     static Arena ofConfined() {
         return MemorySessionImpl.createConfined(Thread.currentThread()).asArena();
@@ -251,6 +260,9 @@ public interface Arena extends SegmentAllocator, AutoCloseable {
     /**
      * {@return a new shared arena} Segments allocated with the global arena can be
      *          {@linkplain MemorySegment#isAccessibleBy(Thread) accessed} by any thread.
+     * <p>
+     * Memory segments {@linkplain #allocate(long, long) allocated} by the returned arena
+     * are zero-initialized.
      */
     static Arena ofShared() {
         return MemorySessionImpl.createShared().asArena();

--- a/test/jdk/java/foreign/TestScope.java
+++ b/test/jdk/java/foreign/TestScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/foreign/TestScope.java
+++ b/test/jdk/java/foreign/TestScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,8 +31,11 @@ import org.testng.annotations.*;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
+import java.util.HexFormat;
+import java.util.stream.LongStream;
 
 import static org.testng.Assert.*;
 
@@ -108,6 +111,30 @@ public class TestScope {
         testDerivedBufferScope(segment1.reinterpret(10));
     }
 
+    @Test
+    public void testZeroedOfAuto() {
+        testZeroed(Arena.ofAuto());
+    }
+
+    @Test
+    public void testZeroedGlobal() {
+        testZeroed(Arena.global());
+    }
+
+    @Test
+    public void testZeroedOfConfined() {
+        try (Arena arena = Arena.ofConfined()) {
+            testZeroed(arena);
+        }
+    }
+
+    @Test
+    public void testZeroedOfShared() {
+        try (Arena arena = Arena.ofShared()) {
+            testZeroed(arena);
+        }
+    }
+
     void testDerivedBufferScope(MemorySegment segment) {
         ByteBuffer buffer = segment.asByteBuffer();
         MemorySegment.Scope expectedScope = segment.scope();
@@ -119,4 +146,14 @@ public class TestScope {
         IntBuffer view = buffer.asIntBuffer();
         assertEquals(expectedScope, MemorySegment.ofBuffer(view).scope());
     }
+
+    private static final MemorySegment ZEROED_MEMORY = MemorySegment.ofArray(new byte[8102]);
+
+    void testZeroed(Arena arena) {
+        long byteSize = ZEROED_MEMORY.byteSize();
+        var segment = arena.allocate(byteSize, Long.BYTES);
+        long mismatch = ZEROED_MEMORY.mismatch(segment);
+        assertEquals(mismatch, -1);
+    }
+
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8323526](https://bugs.openjdk.org/browse/JDK-8323526) to be approved

### Issues
 * [JDK-8323159](https://bugs.openjdk.org/browse/JDK-8323159): Consider adding some text re. memory zeroing in Arena::allocate (**Bug** - P4)
 * [JDK-8323745](https://bugs.openjdk.org/browse/JDK-8323745): Missing comma in copyright header in TestScope (**Bug** - P1)
 * [JDK-8323526](https://bugs.openjdk.org/browse/JDK-8323526): Consider adding some text re. memory zeroing in Arena::allocate (**CSR**)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/77/head:pull/77` \
`$ git checkout pull/77`

Update a local copy of the PR: \
`$ git checkout pull/77` \
`$ git pull https://git.openjdk.org/jdk22.git pull/77/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 77`

View PR using the GUI difftool: \
`$ git pr show -t 77`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/77.diff">https://git.openjdk.org/jdk22/pull/77.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/77#issuecomment-1892463686)