### PR TITLE
8323659: LinkedTransferQueue add and put methods call overridable offer

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/LinkedTransferQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/LinkedTransferQueue.java
@@ -1143,7 +1143,8 @@ public class LinkedTransferQueue<E> extends AbstractQueue<E>
      * @throws NullPointerException if the specified element is null
      */
     public void put(E e) {
-        offer(e);
+        Objects.requireNonNull(e);
+        xfer(e, -1L);
     }
 
     /**
@@ -1156,7 +1157,9 @@ public class LinkedTransferQueue<E> extends AbstractQueue<E>
      * @throws NullPointerException if the specified element is null
      */
     public boolean offer(E e, long timeout, TimeUnit unit) {
-        return offer(e);
+        Objects.requireNonNull(e);
+        xfer(e, -1L);
+        return true;
     }
 
     /**
@@ -1181,7 +1184,9 @@ public class LinkedTransferQueue<E> extends AbstractQueue<E>
      * @throws NullPointerException if the specified element is null
      */
     public boolean add(E e) {
-        return offer(e);
+        Objects.requireNonNull(e);
+        xfer(e, -1L);
+        return true;
     }
 
     /**

--- a/test/jdk/java/util/concurrent/LinkedTransferQueue/SubclassTest.java
+++ b/test/jdk/java/util/concurrent/LinkedTransferQueue/SubclassTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8323659
+ * @summary Ensures that the implementation of LTQ add and put methods does
+ *  not call overridable offer. This test specifically asserts implementation
+ *  details of LTQ. It's not that such impl details cannot change, just that
+ *  such a change should be deliberately done with suitable consideration
+ *  to compatibility.
+ * @run testng SubclassTest
+ */
+
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.TimeUnit;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+
+@Test
+public class SubclassTest {
+
+    public void testPut() {
+        var queue = new TestLinkedTransferQueue();
+        queue.put(new Object());
+        assertEquals(queue.size(), 1);
+    }
+
+    public void testAdd() {
+        var queue = new TestLinkedTransferQueue();
+        queue.add(new Object());
+        assertEquals(queue.size(), 1);
+    }
+
+    public void testTimedOffer() {
+        var queue = new TestLinkedTransferQueue();
+        queue.offer(new Object(), 60, TimeUnit.SECONDS);
+        assertEquals(queue.size(), 1);
+    }
+
+    static class TestLinkedTransferQueue extends LinkedTransferQueue<Object> {
+        @Override
+        public boolean offer(Object obj) {
+            return false;  //  simulate fails to add the given obj
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [ee4d9aa4](https://github.com/openjdk/jdk/commit/ee4d9aa4c11c47e7cf15f2742919ac20311f9ea7) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Chris Hegarty on 16 Jan 2024 and was reviewed by Alan Bateman.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323659](https://bugs.openjdk.org/browse/JDK-8323659): LinkedTransferQueue add and put methods call overridable offer (**Bug** - P2)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/80/head:pull/80` \
`$ git checkout pull/80`

Update a local copy of the PR: \
`$ git checkout pull/80` \
`$ git pull https://git.openjdk.org/jdk22.git pull/80/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 80`

View PR using the GUI difftool: \
`$ git pr show -t 80`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/80.diff">https://git.openjdk.org/jdk22/pull/80.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/80#issuecomment-1893647965)