### PR TITLE
8323651: compiler/c2/irTests/TestPrunedExHandler.java fails with -XX:+DeoptimizeALot

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestPrunedExHandler.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestPrunedExHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import compiler.lib.ir_framework.*;
  * @bug 8267532
  * @summary check that uncommon trap is generated for unhandled catch block
  * @library /test/lib /
+ * @requires vm.opt.DeoptimizeALot != true
  * @run driver compiler.c2.irTests.TestPrunedExHandler
  */
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [2fd775f6](https://github.com/openjdk/jdk/commit/2fd775f69c8eb4d0bd1163e8b5d2615db105352b) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jorn Vernee on 16 Jan 2024 and was reviewed by Alan Bateman and Vladimir Kozlov.

This is a P4 test-only change, and we are currently in Ramp Down Phase 1. The release process allows P1-P5 test-only changes during RDP1: https://openjdk.org/jeps/3#Quick-reference

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323651](https://bugs.openjdk.org/browse/JDK-8323651): compiler/c2/irTests/TestPrunedExHandler.java fails with -XX:+DeoptimizeALot (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/82/head:pull/82` \
`$ git checkout pull/82`

Update a local copy of the PR: \
`$ git checkout pull/82` \
`$ git pull https://git.openjdk.org/jdk22.git pull/82/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 82`

View PR using the GUI difftool: \
`$ git pr show -t 82`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/82.diff">https://git.openjdk.org/jdk22/pull/82.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/82#issuecomment-1893855590)