### PR TITLE
8322657: CDS filemap fastdebug assert while loading Graal CE Polyglot in isolated classloader

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -576,12 +576,14 @@ int FileMapInfo::get_module_shared_path_index(Symbol* location) {
   const char* file = ClassLoader::skip_uri_protocol(location->as_C_string());
   for (int i = ClassLoaderExt::app_module_paths_start_index(); i < get_number_of_shared_paths(); i++) {
     SharedClassPathEntry* ent = shared_path(i);
-    assert(ent->in_named_module(), "must be");
-    bool cond = strcmp(file, ent->name()) == 0;
-    log_debug(class, path)("get_module_shared_path_index (%d) %s : %s = %s", i,
-                           location->as_C_string(), ent->name(), cond ? "same" : "different");
-    if (cond) {
-      return i;
+    if (!ent->is_non_existent()) {
+      assert(ent->in_named_module(), "must be");
+      bool cond = strcmp(file, ent->name()) == 0;
+      log_debug(class, path)("get_module_shared_path_index (%d) %s : %s = %s", i,
+                             location->as_C_string(), ent->name(), cond ? "same" : "different");
+      if (cond) {
+        return i;
+      }
     }
   }
 

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,6 +89,7 @@ public:
   bool is_dir()           const { return _type == dir_entry; }
   bool is_modules_image() const { return _type == modules_image_entry; }
   bool is_jar()           const { return _type == jar_entry; }
+  bool is_non_existent()  const { return _type == non_existent_entry; }
   bool from_class_path_attr() { return _from_class_path_attr; }
   time_t timestamp() const { return _timestamp; }
   const char* name() const;

--- a/test/hotspot/jtreg/runtime/cds/appcds/JarBuilder.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/JarBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -193,6 +193,23 @@ public class JarBuilder {
         if (mainClass != null) {
             argList.add("--main-class=" + mainClass);
         }
+        argList.add("-C");
+        argList.add(classesDir);
+        argList.add(".");
+        createJar(argList);
+    }
+
+    public static void createModularJarWithManifest(String jarPath,
+                                                    String classesDir,
+                                                    String mainClass,
+                                                    String manifest) throws Exception {
+        ArrayList<String> argList = new ArrayList<String>();
+        argList.add("--create");
+        argList.add("--file=" + jarPath);
+        if (mainClass != null) {
+            argList.add("--main-class=" + mainClass);
+        }
+        argList.add("--manifest=" + manifest);
         argList.add("-C");
         argList.add(classesDir);
         argList.add(".");

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ModularJarWithNonExistentJar.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/ModularJarWithNonExistentJar.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/**
+ * @test
+ * @bug 8322657
+ * @summary This test defines an application module using the DefineModuleApp.
+ *          When performing dynamic dump, the modular jar containing the module
+ *          is in the -cp. The jar listed in the "Class-Path" attribute of the modular
+ *          jar doesn't exist. VM should not crash during dynamic dump under this scenario.
+ * @requires vm.cds
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ *          /test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes
+ * @build jdk.test.whitebox.WhiteBox DefineModuleApp
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar define_module_app.jar DefineModuleApp
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. ModularJarWithNonExistentJar
+ */
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.helpers.ClassFileInstaller;
+
+public class ModularJarWithNonExistentJar extends DynamicArchiveTestBase {
+    private static final Path USER_DIR = Paths.get(CDSTestUtils.getOutputDir());
+
+    private static final String TEST_SRC = System.getProperty("test.src");
+
+    private static final Path SRC_DIR = Paths.get(TEST_SRC, "../jigsaw/modulepath/src");
+    private static final Path MODS_DIR = Paths.get("mods");
+    private static final Path MANIFEST_PATH = Paths.get(TEST_SRC, "test-classes/manifest-with-non-existent-jar.txt");
+
+    // the module name of the test module
+    private static final String TEST_MODULE = "com.simple";
+
+    // the module main class
+    private static final String MAIN_CLASS = "com.simple.Main";
+
+    private static Path moduleDir = null;
+    private static Path modularJar = null;
+
+    public static void buildTestModule() throws Exception {
+
+        // javac -d mods/$TESTMODULE --module-path MOD_DIR src/$TESTMODULE/**
+        JarBuilder.compileModule(SRC_DIR.resolve(TEST_MODULE),
+                                 MODS_DIR.resolve(TEST_MODULE),
+                                 MODS_DIR.toString());
+
+
+        moduleDir = Files.createTempDirectory(USER_DIR, "mlib");
+
+        modularJar = moduleDir.resolve(TEST_MODULE + ".jar");
+        String classes = MODS_DIR.resolve(TEST_MODULE).toString();
+        JarBuilder.createModularJarWithManifest(modularJar.toString(), classes,
+                                                MAIN_CLASS, MANIFEST_PATH.toString());
+    }
+
+    public static void main(String... args) throws Exception {
+        runTest(ModularJarWithNonExistentJar::testDefaultBase);
+    }
+
+    static void testDefaultBase() throws Exception {
+        String topArchiveName = getNewArchiveName("top");
+        doTest(topArchiveName);
+    }
+
+    private static void doTest(String topArchiveName) throws Exception {
+        // compile the module and create the modular jar file
+        buildTestModule();
+        String appJar = ClassFileInstaller.getJarPath("define_module_app.jar");
+        dump(topArchiveName,
+             "-Xlog:cds,class+path=info",
+             "-Xlog:cds+dynamic=debug",
+             "-cp", appJar + File.pathSeparator + modularJar.toString(),
+             "DefineModuleApp", moduleDir.toString(), TEST_MODULE)
+            .assertNormalExit(output -> {
+                    output.shouldContain("Written dynamic archive 0x");
+                });
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/DefineModuleApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/DefineModuleApp.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/**
+ * This app defines a module using the ModuleLayer.defineModulesWithOneLoader API
+ * which calls the JVM_DefineModule.
+ **/
+
+import java.nio.file.Path;
+import java.lang.ModuleLayer.Controller;
+import java.lang.module.*;
+import java.util.List;
+import java.util.Set;
+
+public class DefineModuleApp {
+    public static void main(String[] args) throws Throwable {
+        if (args.length != 2) {
+            throw new RuntimeException("DefineModuleApp expects 2 args but saw " + args.length);
+        }
+        final Path MODS = Path.of(args[0]);
+        final String MODULE_NAME = args[1];
+        Configuration cf = ModuleLayer.boot()
+                .configuration()
+                .resolve(ModuleFinder.of(), ModuleFinder.of(MODS), Set.of(MODULE_NAME));
+        ResolvedModule m = cf.findModule(MODULE_NAME).orElseThrow();
+        ModuleLayer bootLayer = ModuleLayer.boot();
+        ClassLoader scl = ClassLoader.getSystemClassLoader();
+        Controller controller = ModuleLayer.defineModulesWithOneLoader(cf, List.of(bootLayer), scl);
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/manifest-with-non-existent-jar.txt
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/manifest-with-non-existent-jar.txt
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Class-Path: NonExistent.jar
+Created-By: 23-internal (Oracle Corporation)


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [841ab487](https://github.com/openjdk/jdk/commit/841ab487f83d7e3639d352e796dc7131310c2390) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Calvin Cheung on 8 Jan 2024 and was reviewed by Matias Saavedra Silva and David Holmes.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322657](https://bugs.openjdk.org/browse/JDK-8322657): CDS filemap fastdebug assert while loading Graal CE Polyglot in isolated classloader (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/85/head:pull/85` \
`$ git checkout pull/85`

Update a local copy of the PR: \
`$ git checkout pull/85` \
`$ git pull https://git.openjdk.org/jdk22.git pull/85/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 85`

View PR using the GUI difftool: \
`$ git pr show -t 85`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/85.diff">https://git.openjdk.org/jdk22/pull/85.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/85#issuecomment-1894658611)