### PR TITLE
8323675: Race in jdk.javadoc-gendata

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -962,20 +962,28 @@ else
 
   jdk.jdeps-gendata: java
 
-  # The ct.sym generation uses all the moduleinfos as input
-  jdk.compiler-gendata: $(GENSRC_MODULEINFO_TARGETS) $(JAVA_TARGETS)
-  # jdk.compiler-gendata needs the BUILD_JDK. If the BUILD_JDK was supplied
-  # externally, no extra prerequisites are needed.
+  # jdk.compiler gendata generates ct.sym, which requires all generated
+  # java source and compiled classes present.
+  jdk.compiler-gendata: $(JAVA_TARGETS)
+
+  # jdk.javadoc gendata generates element-list, which requires all java sources
+  # but not compiled classes.
+  jdk.javadoc-gendata: $(GENSRC_TARGETS)
+
+  # ct.sym and element-list generation also needs the BUILD_JDK. If the
+  # BUILD_JDK was supplied externally, no extra prerequisites are needed.
   ifeq ($(CREATE_BUILDJDK), true)
     ifneq ($(CREATING_BUILDJDK), true)
       # When cross compiling and an external BUILD_JDK wasn't supplied, it's
       # produced by the create-buildjdk target.
       jdk.compiler-gendata: create-buildjdk
+      jdk.javadoc-gendata: create-buildjdk
     endif
   else ifeq ($(EXTERNAL_BUILDJDK), false)
     # When not cross compiling, the BUILD_JDK is the interim jdk image, and
     # the javac launcher is needed.
     jdk.compiler-gendata: jdk.compiler-launchers
+    jdk.javadoc-gendata: jdk.compiler-launchers
   endif
 
   # Declare dependencies between jmod targets.


### PR DESCRIPTION
This pull request contains a backport of commit [9049402a](https://github.com/openjdk/jdk/commit/9049402a1b9394095b04287eef1f2d46c4da60e9) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Magnus Ihse Bursie on 19 Jan 2024 and was reviewed by Erik Joelsson and Jan Lahoda.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323675](https://bugs.openjdk.org/browse/JDK-8323675): Race in jdk.javadoc-gendata (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/96/head:pull/96` \
`$ git checkout pull/96`

Update a local copy of the PR: \
`$ git checkout pull/96` \
`$ git pull https://git.openjdk.org/jdk22.git pull/96/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 96`

View PR using the GUI difftool: \
`$ git pr show -t 96`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/96.diff">https://git.openjdk.org/jdk22/pull/96.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/96#issuecomment-1906403112)