### PR TITLE
8324688: C2: Disable ReduceAllocationMerges by default

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -467,7 +467,7 @@
   develop(bool, TracePostallocExpand, false, "Trace expanding nodes after"  \
           " register allocation.")                                          \
                                                                             \
-  product(bool, ReduceAllocationMerges, true, DIAGNOSTIC,                   \
+  product(bool, ReduceAllocationMerges, false, DIAGNOSTIC,                  \
           "Try to simplify allocation merges before Scalar Replacement")    \
                                                                             \
   notproduct(bool, TraceReduceAllocationMerges, false,                      \


### PR DESCRIPTION
Due to several recent bug reports after the integration of [JDK-8287061](https://bugs.openjdk.org/browse/JDK-8287061) in JDK 22 (latest one being [JDK-8322854](https://bugs.openjdk.org/browse/JDK-8322854)), we've decided together with @JohnTortugo that we want to minimize the risk and that it's best to disable `ReduceAllocationMerges` by default for JDK 22 which disables the optimizations of [JDK-8287061](https://bugs.openjdk.org/browse/JDK-8287061). 

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324688](https://bugs.openjdk.org/browse/JDK-8324688): C2: Disable ReduceAllocationMerges by default (**Bug** - P2)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/97/head:pull/97` \
`$ git checkout pull/97`

Update a local copy of the PR: \
`$ git checkout pull/97` \
`$ git pull https://git.openjdk.org/jdk22.git pull/97/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 97`

View PR using the GUI difftool: \
`$ git pr show -t 97`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/97.diff">https://git.openjdk.org/jdk22/pull/97.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/97#issuecomment-1909860464)