### PR TITLE
8323556: CDS archive space addresses should be randomized with ArchiveRelocationMode=1

### DIFF
--- a/src/hotspot/cpu/aarch64/compressedKlass_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/compressedKlass_aarch64.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@ static char* reserve_at_eor_compatible_address(size_t size, bool aslr) {
       0x7ffc, 0x7ffe, 0x7fff
   };
   static constexpr int num_immediates = sizeof(immediates) / sizeof(immediates[0]);
-  const int start_index = aslr ? os::random() : 0;
+  const int start_index = aslr ? os::next_random((int)os::javaTimeNanos()) : 0;
   constexpr int max_tries = 64;
   for (int ntry = 0; result == nullptr && ntry < max_tries; ntry ++) {
     // As in os::attempt_reserve_memory_between, we alternate between higher and lower


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [437342b9](https://github.com/openjdk/jdk/commit/437342b93e9e66340ac57bd1c6fdc948b3302db0) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Calvin Cheung on 19 Jan 2024 and was reviewed by Ioi Lam and Matias Saavedra Silva.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323556](https://bugs.openjdk.org/browse/JDK-8323556): CDS archive space addresses should be randomized with ArchiveRelocationMode=1 (**Bug** - P2)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/98/head:pull/98` \
`$ git checkout pull/98`

Update a local copy of the PR: \
`$ git checkout pull/98` \
`$ git pull https://git.openjdk.org/jdk22.git pull/98/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 98`

View PR using the GUI difftool: \
`$ git pr show -t 98`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/98.diff">https://git.openjdk.org/jdk22/pull/98.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/98#issuecomment-1912582017)