### PR TITLE
8322066: Update troff manpages in JDK 22 before RC

### DIFF
--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -36,7 +36,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAVA" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JAVA" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP
@@ -63,7 +63,7 @@ or
 \f[V]java\f[R] [\f[I]options\f[R]] \f[V]--module\f[R]
 \f[I]module\f[R][\f[V]/\f[R]\f[I]mainclass\f[R]] [\f[I]args\f[R] ...]
 .PP
-To launch a single source-file program:
+To launch a source-file program:
 .PP
 \f[V]java\f[R] [\f[I]options\f[R]] \f[I]source-file\f[R] [\f[I]args\f[R]
 \&...]
@@ -100,11 +100,10 @@ See \f[B]Standard Options for Java\f[R].
 .RE
 .TP
 \f[I]source-file\f[R]
-Only used to launch a single source-file program.
+Only used to launch a source-file program.
 Specifies the source file that contains the main class when using
 source-file mode.
-See \f[B]Using Source-File Mode to Launch Single-File Source-Code
-Programs\f[R]
+See \f[B]Using Source-File Mode to Launch Source-Code Programs\f[R]
 .TP
 \f[I]args\f[R] ...
 Optional: Arguments following \f[I]mainclass\f[R],
@@ -128,8 +127,8 @@ The method declaration has the following form:
 .PP
 In source-file mode, the \f[V]java\f[R] command can launch a class
 declared in a source file.
-See \f[B]Using Source-File Mode to Launch Single-File Source-Code
-Programs\f[R] for a description of using the source-file mode.
+See \f[B]Using Source-File Mode to Launch Source-Code Programs\f[R] for
+a description of using the source-file mode.
 .RS
 .PP
 \f[B]Note:\f[R] You can use the \f[V]JDK_JAVA_OPTIONS\f[R] launcher
@@ -157,7 +156,7 @@ Use \f[V]javaw\f[R] when you don\[aq]t want a command prompt window to
 appear.
 The \f[V]javaw\f[R] launcher will, however, display a dialog box with
 error information if a launch fails.
-.SH USING SOURCE-FILE MODE TO LAUNCH SINGLE-FILE SOURCE-CODE PROGRAMS
+.SH USING SOURCE-FILE MODE TO LAUNCH SOURCE-CODE PROGRAMS
 .PP
 To launch a class declared in a source file, run the \f[V]java\f[R]
 launcher in source-file mode.
@@ -205,25 +204,24 @@ Any arguments placed after the name of the source file in the original
 command line are passed to the compiled class when it is executed.
 .PP
 For example, if a file were named \f[V]HelloWorld.java\f[R] and
-contained a class named \f[V]hello.World\f[R], then the source-file mode
+contained a class named \f[V]HelloWorld\f[R], then the source-file mode
 command to launch the class would be:
 .RS
 .PP
 \f[V]java HelloWorld.java\f[R]
 .RE
 .PP
-The example illustrates that the class can be in a named package, and
-does not need to be in the unnamed package.
 This use of source-file mode is informally equivalent to using the
-following two commands where \f[V]hello.World\f[R] is the name of the
-class in the package:
+following two commands:
 .IP
 .nf
 \f[CB]
-javac -d <memory> HelloWorld.java
-java -cp <memory> hello.World
+javac -d <memory> --source-path <source-root> HelloWorld.java
+java --class-path <memory> HelloWorld
 \f[R]
 .fi
+.PP
+where \f[V]<source-root>\f[R] is computed
 .PP
 \f[B]In source-file mode, any additional command-line options are
 processed as follows:\f[R]
@@ -253,9 +251,24 @@ filename with an \f[V]\[at]\f[R] character.
 .IP \[bu] 2
 Any command-line options that are relevant to the compilation
 environment are taken into account.
+These include:
+\f[V]--class-path\f[R]/\f[V]-classpath\f[R]/\f[V]-cp\f[R],
+\f[V]--module-path\f[R]/\f[V]-p\f[R], \f[V]--add-exports\f[R],
+\f[V]--add-modules\f[R], \f[V]--limit-modules\f[R],
+\f[V]--patch-module\f[R], \f[V]--upgrade-module-path\f[R],
+\f[V]--enable-preview\f[R].
 .IP \[bu] 2
-No other source files are found and compiled, as if the source path is
-set to an empty value.
+The root of the source tree, \f[V]<source-root>\f[R] is computed from
+the package of the class being launched.
+For example, if \f[V]HelloWorld.java\f[R] declared its classes to be in
+the \f[V]hello\f[R] package, then the file \f[V]HelloWorld.java\f[R] is
+expected to reside in the directory \f[V]somedir/hello/\f[R].
+In this case, \f[V]somedir\f[R] is computed to be the root of the source
+tree.
+.IP \[bu] 2
+The root of the source tree serves as the source-path for compilation,
+so that other source files found in that tree and are needed by
+\f[V]HelloWorld\f[R] could be compiled.
 .IP \[bu] 2
 Annotation processing is disabled, as if \f[V]-proc:none\f[R] is in
 effect.
@@ -266,45 +279,54 @@ the compilation.
 This sets both the source version accepted by compiler and the system
 API that may be used by the code in the source file.
 .IP \[bu] 2
-The source file is compiled in the context of an unnamed module.
+If a \f[V]module-info.java\f[R] file exists in the
+\f[V]<source-root>\f[R] directory, its module declaration is used to
+define a named module that will contain all the classes compiled from
+\f[V].java\f[R] files in the source tree.
+If \f[V]module-info.java\f[R] does not exist, all the classes compiled
+from source files will be compiled in the context of the unnamed module.
 .IP \[bu] 2
-The source file should contain one or more top-level classes, the first
-of which is taken as the class to be executed.
+The source file that is launched should contain one or more top-level
+classes, the first of which is taken as the class to be executed.
 .IP \[bu] 2
-The compiler does not enforce the optional restriction defined at the
-end of JLS 7.6, that a type in a named package should exist in a file
-whose name is composed from the type name followed by the
-\f[V].java\f[R] extension.
+For the source file that is launched, the compiler does not enforce the
+optional restriction defined at the end of JLS 7.6, that a type in a
+named package should exist in a file whose name is composed from the
+type name followed by the \f[V].java\f[R] extension.
 .IP \[bu] 2
-If the source file contains errors, appropriate error messages are
-written to the standard error stream, and the launcher exits with a
-non-zero exit code.
+If a source file contains errors, appropriate error messages are written
+to the standard error stream, and the launcher exits with a non-zero
+exit code.
 .PP
 \f[B]In source-file mode, execution proceeds as follows:\f[R]
 .IP \[bu] 2
 The class to be executed is the first top-level class found in the
 source file.
-It must contain a declaration of the standard
-\f[V]public static void main(String[])\f[R] method.
+It must contain a declaration of an entry \f[V]main\f[R] method.
 .IP \[bu] 2
 The compiled classes are loaded by a custom class loader, that delegates
 to the application class loader.
 This implies that classes appearing on the application class path cannot
-refer to any classes declared in the source file.
+refer to any classes declared in source files.
 .IP \[bu] 2
-The compiled classes are executed in the context of an unnamed module,
-as though \f[V]--add-modules=ALL-DEFAULT\f[R] is in effect.
+If a \f[V]module-info.java\f[R] file exists in the
+\f[V]<source-root>\f[R] directory, then all the classes compiled from
+\f[V].java\f[R] files in the source tree will be in that module, which
+will serve as the root module for the execution of the program.
+If \f[V]module-info.java\f[R] does not exist, the compiled classes are
+executed in the context of an unnamed module, as though
+\f[V]--add-modules=ALL-DEFAULT\f[R] is in effect.
 This is in addition to any other \f[V]--add-module\f[R] options that may
 be have been specified on the command line.
 .IP \[bu] 2
 Any arguments appearing after the name of the file on the command line
-are passed to the standard main method in the obvious way.
+are passed to the main method in the obvious way.
 .IP \[bu] 2
 It is an error if there is a class on the application class path whose
 name is the same as that of the class to be executed.
 .PP
-See \f[B]JEP 330: Launch Single-File Source-Code Programs\f[R]
-[https://openjdk.org/jeps/330] for complete details.
+See \f[B]JEP 458: Launch Multi-File Source-Code Programs\f[R]
+[https://openjdk.org/jeps/458] for complete details.
 .SH USING THE JDK_JAVA_OPTIONS LAUNCHER ENVIRONMENT VARIABLE
 .PP
 \f[V]JDK_JAVA_OPTIONS\f[R] prepends its content to the options parsed

--- a/src/java.base/share/man/keytool.1
+++ b/src/java.base/share/man/keytool.1
@@ -36,7 +36,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "KEYTOOL" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "KEYTOOL" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP
@@ -452,17 +452,32 @@ The certificate chain and private key are stored in a new keystore entry
 that is identified by its alias.
 .PP
 The \f[V]-keyalg\f[R] value specifies the algorithm to be used to
-generate the key pair, and the \f[V]-keysize\f[R] value specifies the
-size of each key to be generated.
-The \f[V]-sigalg\f[R] value specifies the algorithm that should be used
-to sign the certificate.
-This algorithm must be compatible with the \f[V]-keyalg\f[R] value.
-.PP
+generate the key pair.
+The \f[V]-keysize\f[R] value specifies the size of each key to be
+generated.
 The \f[V]-groupname\f[R] value specifies the named group (for example,
 the standard or predefined name of an Elliptic Curve) of the key to be
 generated.
+.PP
+When a \f[V]-keysize\f[R] value is provided, it will be used to
+initialize a \f[V]KeyPairGenerator\f[R] object using the
+\f[V]initialize(int keysize)\f[R] method.
+When a \f[V]-groupname\f[R] value is provided, it will be used to
+initialize a \f[V]KeyPairGenerator\f[R] object using the
+\f[V]initialize(AlgorithmParameterSpec params)\f[R] method where
+\f[V]params\f[R] is \f[V]new NamedParameterSpec(groupname)\f[R].
+.PP
 Only one of \f[V]-groupname\f[R] and \f[V]-keysize\f[R] can be
 specified.
+If an algorithm has multiple named groups that have the same key size,
+the \f[V]-groupname\f[R] option should usually be used.
+In this case, if \f[V]-keysize\f[R] is specified, it\[aq]s up to the
+security provider to determine which named group is chosen when
+generating a key pair.
+.PP
+The \f[V]-sigalg\f[R] value specifies the algorithm that should be used
+to sign the certificate.
+This algorithm must be compatible with the \f[V]-keyalg\f[R] value.
 .PP
 The \f[V]-signer\f[R] value specifies the alias of a
 \f[V]PrivateKeyEntry\f[R] for the signer that already exists in the
@@ -1570,9 +1585,12 @@ The following examples show the defaults for various option values:
     2048 (when using -genkeypair and -keyalg is \[dq]DSA\[dq])
     3072 (when using -genkeypair and -keyalg is \[dq]RSA\[dq], \[dq]RSASSA-PSS\[dq], or \[dq]DH\[dq])
     384 (when using -genkeypair and -keyalg is \[dq]EC\[dq])
-    255 (when using -genkeypair and -keyalg is \[dq]EdDSA\[dq], or \[dq]XDH)
     56 (when using -genseckey and -keyalg is \[dq]DES\[dq])
     168 (when using -genseckey and -keyalg is \[dq]DESede\[dq])
+
+-groupname
+    ed25519 (when using -genkeypair and -keyalg is \[dq]EdDSA\[dq], key size is 255)
+    x25519 (when using -genkeypair and -keyalg is \[dq]XDH\[dq], key size is 255)
 
 -validity 90
 
@@ -1604,7 +1622,7 @@ l l l.
 T{
 keyalg
 T}@T{
-keysize
+key size
 T}@T{
 default sigalg
 T}
@@ -1621,7 +1639,7 @@ RSA
 T}@T{
 < 624
 T}@T{
-SHA256withRSA (keysize is too small for using SHA-384)
+SHA256withRSA (key size is too small for using SHA-384)
 T}
 T{
 T}@T{
@@ -1653,7 +1671,7 @@ RSASSA-PSS
 T}@T{
 < 624
 T}@T{
-RSASSA-PSS (with SHA-256, keysize is too small for
+RSASSA-PSS (with SHA-256, key size is too small for
 T}
 T{
 T}@T{
@@ -1701,28 +1719,29 @@ Ed448
 T}
 .TE
 .IP \[bu] 2
+The key size, measured in bits, corresponds to the size of the private
+key.
+This size is determined by the value of the \f[V]-keysize\f[R] or
+\f[V]-groupname\f[R] options or the value derived from a default
+setting.
+.IP \[bu] 2
 An RSASSA-PSS signature algorithm uses a \f[V]MessageDigest\f[R]
 algorithm as its hash and MGF1 algorithms.
 .IP \[bu] 2
-EdDSA supports 2 key sizes: Ed25519 and Ed448.
-When generating an EdDSA key pair using \f[V]-keyalg EdDSA\f[R], a user
-can specify \f[V]-keysize 255\f[R] or \f[V]-keysize 448\f[R] to generate
-Ed25519 or Ed448 key pairs.
-When no \f[V]-keysize\f[R] is specified, an Ed25519 key pair is
-generated.
-A user can also directly specify \f[V]-keyalg Ed25519\f[R] or
-\f[V]-keyalg Ed448\f[R] to generate a key pair with the expected key
-size.
+If neither a default \f[V]-keysize\f[R] or \f[V]-groupname\f[R] is
+defined for an algorithm, the security provider will choose a default
+setting.
 .PP
 \f[B]Note:\f[R]
 .PP
-To improve out of the box security, default key size and signature
-algorithm names are periodically updated to stronger values with each
-release of the JDK.
+To improve out of the box security, default keysize, groupname, and
+signature algorithm names are periodically updated to stronger values
+with each release of the JDK.
 If interoperability with older releases of the JDK is important, make
 sure that the defaults are supported by those releases.
-Alternatively, you can use the \f[V]-keysize\f[R] or \f[V]-sigalg\f[R]
-options to override the default values at your own risk.
+Alternatively, you can use the \f[V]-keysize\f[R], \f[V]-groupname\f[R],
+or \f[V]-sigalg\f[R] options to override the default values at your own
+risk.
 .SH SUPPORTED NAMED EXTENSIONS
 .PP
 The \f[V]keytool\f[R] command supports these named extensions.

--- a/src/java.rmi/share/man/rmiregistry.1
+++ b/src/java.rmi/share/man/rmiregistry.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "RMIREGISTRY" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "RMIREGISTRY" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/java.scripting/share/man/jrunscript.1
+++ b/src/java.scripting/share/man/jrunscript.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JRUNSCRIPT" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JRUNSCRIPT" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.compiler/share/man/javac.1
+++ b/src/jdk.compiler/share/man/javac.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAVAC" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JAVAC" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.compiler/share/man/serialver.1
+++ b/src/jdk.compiler/share/man/serialver.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "SERIALVER" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "SERIALVER" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.hotspot.agent/share/man/jhsdb.1
+++ b/src/jdk.hotspot.agent/share/man/jhsdb.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JHSDB" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JHSDB" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.httpserver/share/man/jwebserver.1
+++ b/src/jdk.httpserver/share/man/jwebserver.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JWEBSERVER" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JWEBSERVER" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jartool/share/man/jar.1
+++ b/src/jdk.jartool/share/man/jar.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAR" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JAR" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP
@@ -186,7 +186,8 @@ created or a non-modular JAR file being updated.
 Specifies the location of module dependence for generating the hash.
 .TP
 \f[V]\[at]\f[R]\f[I]file\f[R]
-Reads \f[V]jar\f[R] options and file names from a text file.
+Reads \f[V]jar\f[R] options and file names from a text file as if they
+were supplied on the command line
 .SH OPERATION MODIFIERS VALID ONLY IN CREATE, UPDATE, AND GENERATE-INDEX MODES
 .PP
 You can use the following options to customize the actions of the create
@@ -330,11 +331,14 @@ class files from the file \f[V]classes.list\f[R].
 .PP
 \f[B]Note:\f[R]
 .PP
-To shorten or simplify the \f[V]jar\f[R] command, you can specify
-arguments in a separate text file and pass it to the \f[V]jar\f[R]
-command with the at sign (\f[V]\[at]\f[R]) as a prefix.
+To shorten or simplify the \f[V]jar\f[R] command, you can provide an arg
+file that lists the files to include in the JAR file and pass it to the
+\f[V]jar\f[R] command with the at sign (\f[V]\[at]\f[R]) as a prefix.
 .RS
 .PP
 \f[V]jar --create --file my.jar \[at]classes.list\f[R]
 .RE
+.PP
+If one or more entries in the arg file cannot be found then the jar
+command fails without creating the JAR file.
 .RE

--- a/src/jdk.jartool/share/man/jarsigner.1
+++ b/src/jdk.jartool/share/man/jarsigner.1
@@ -36,7 +36,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JARSIGNER" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JARSIGNER" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP
@@ -318,7 +318,7 @@ l l l l.
 T{
 keyalg
 T}@T{
-keysize
+key size
 T}@T{
 default sigalg
 T}@T{
@@ -420,6 +420,9 @@ Otherwise, jarsigner will use parameters that are determined by the size
 of the key as specified in the table above.
 For example, an 3072-bit RSASSA-PSS key will use RSASSA-PSS as the
 signature algorithm and SHA-384 as the hash and MGF1 algorithms.
+.IP \[bu] 2
+If a key algorithm is not listed in this table, the \f[V].DSA\f[R]
+extension is used when signing a JAR file.
 .PP
 These default signature algorithms can be overridden by using the
 \f[V]-sigalg\f[R] option.
@@ -805,8 +808,8 @@ Specifies the name of the message digest algorithm to use when digesting
 the entries of a JAR file.
 .RS
 .PP
-For a list of standard message digest algorithm names, see Java Security
-Standard Algorithm Names.
+For a list of standard message digest algorithm names, see the Java
+Security Standard Algorithm Names Specification.
 .PP
 If this option isn\[aq]t specified, then \f[V]SHA-384\f[R] is used.
 There must either be a statically installed provider supplying an
@@ -830,8 +833,8 @@ implementation of the specified algorithm or you must specify one with
 the \f[V]-addprovider\f[R] or \f[V]-providerClass\f[R] option;
 otherwise, the command doesn\[aq]t succeed.
 .PP
-For a list of standard message digest algorithm names, see Java Security
-Standard Algorithm Names.
+For a list of standard signature algorithm names, see the Java Security
+Standard Algorithm Names Specification.
 .RE
 .TP
 \f[V]-verify\f[R]
@@ -946,8 +949,8 @@ If this option isn\[aq]t specified, SHA-384 will be used.
 .PP
 See \f[B]Supported Algorithms\f[R].
 .PP
-For a list of standard message digest algorithm names, see Java Security
-Standard Algorithm Names.
+For a list of standard message digest algorithm names, see the Java
+Security Standard Algorithm Names Specification.
 .RE
 .TP
 \f[V]-internalsf\f[R]

--- a/src/jdk.javadoc/share/man/javadoc.1
+++ b/src/jdk.javadoc/share/man/javadoc.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAVADOC" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JAVADOC" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jcmd.1
+++ b/src/jdk.jcmd/share/man/jcmd.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JCMD" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JCMD" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jinfo.1
+++ b/src/jdk.jcmd/share/man/jinfo.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JINFO" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JINFO" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jmap.1
+++ b/src/jdk.jcmd/share/man/jmap.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JMAP" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JMAP" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jps.1
+++ b/src/jdk.jcmd/share/man/jps.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JPS" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JPS" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jstack.1
+++ b/src/jdk.jcmd/share/man/jstack.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JSTACK" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JSTACK" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jstat.1
+++ b/src/jdk.jcmd/share/man/jstat.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JSTAT" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JSTAT" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jconsole/share/man/jconsole.1
+++ b/src/jdk.jconsole/share/man/jconsole.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JCONSOLE" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JCONSOLE" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jdeps/share/man/javap.1
+++ b/src/jdk.jdeps/share/man/javap.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAVAP" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JAVAP" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jdeps/share/man/jdeprscan.1
+++ b/src/jdk.jdeps/share/man/jdeprscan.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JDEPRSCAN" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JDEPRSCAN" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jdeps/share/man/jdeps.1
+++ b/src/jdk.jdeps/share/man/jdeps.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JDEPS" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JDEPS" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jdi/share/man/jdb.1
+++ b/src/jdk.jdi/share/man/jdb.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JDB" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JDB" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jfr/share/man/jfr.1
+++ b/src/jdk.jfr/share/man/jfr.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JFR" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JFR" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jlink/share/man/jlink.1
+++ b/src/jdk.jlink/share/man/jlink.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JLINK" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JLINK" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jlink/share/man/jmod.1
+++ b/src/jdk.jlink/share/man/jmod.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JMOD" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JMOD" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jpackage/share/man/jpackage.1
+++ b/src/jdk.jpackage/share/man/jpackage.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JPACKAGE" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JPACKAGE" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jshell/share/man/jshell.1
+++ b/src/jdk.jshell/share/man/jshell.1
@@ -36,7 +36,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JSHELL" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JSHELL" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jstatd/share/man/jstatd.1
+++ b/src/jdk.jstatd/share/man/jstatd.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JSTATD" "1" "2024" "JDK 22-ea" "JDK Commands"
+.TH "JSTATD" "1" "2024" "JDK 22" "JDK Commands"
 .hy
 .SH NAME
 .PP


### PR DESCRIPTION
This update drops the "ea" from the version string.

We also propagate the following fixes from the markdown sources to the troff manpage file:

JDK-8322478: Update java manpage for multi-file source-code launcher
JDK-8302233: HSS/LMS: keytool and jarsigner changes
JDK-8318971: Better Error Handling for Jar Tool When Processing Non-existent Files


Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322066](https://bugs.openjdk.org/browse/JDK-8322066): Update troff manpages in JDK 22 before RC (**Task** - P3)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/104/head:pull/104` \
`$ git checkout pull/104`

Update a local copy of the PR: \
`$ git checkout pull/104` \
`$ git pull https://git.openjdk.org/jdk22.git pull/104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 104`

View PR using the GUI difftool: \
`$ git pr show -t 104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/104.diff">https://git.openjdk.org/jdk22/pull/104.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/104#issuecomment-1925953900)