### PR TITLE
8324858: [vectorapi] Bounds checking issues when accessing memory segments

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractSpecies.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractSpecies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -358,14 +358,6 @@ abstract class AbstractSpecies<E> extends jdk.internal.vm.vector.VectorSupport.V
             return dummyVector().iotaShuffle();
         else
             return dummyVector().iotaShuffle(start, step, wrap);
-    }
-
-    @ForceInline
-    @Override
-    public final Vector<E> fromMemorySegment(MemorySegment ms, long offset, ByteOrder bo) {
-        return dummyVector()
-            .fromMemorySegment0(ms, offset)
-            .maybeSwap(bo);
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -4194,9 +4194,19 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         @ForceInline
         @Override final
         public ByteVector fromArray(Object a, int offset) {
-            // User entry point:  Be careful with inputs.
+            // User entry point
+            // Defer only to the equivalent method on the vector class, using the same inputs
             return ByteVector
                 .fromArray(this, (byte[]) a, offset);
+        }
+
+        @ForceInline
+        @Override final
+        public ByteVector fromMemorySegment(MemorySegment ms, long offset, ByteOrder bo) {
+            // User entry point
+            // Defer only to the equivalent method on the vector class, using the same inputs
+            return ByteVector
+                .fromMemorySegment(this, ms, offset, bo);
         }
 
         @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3797,9 +3797,19 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         @ForceInline
         @Override final
         public DoubleVector fromArray(Object a, int offset) {
-            // User entry point:  Be careful with inputs.
+            // User entry point
+            // Defer only to the equivalent method on the vector class, using the same inputs
             return DoubleVector
                 .fromArray(this, (double[]) a, offset);
+        }
+
+        @ForceInline
+        @Override final
+        public DoubleVector fromMemorySegment(MemorySegment ms, long offset, ByteOrder bo) {
+            // User entry point
+            // Defer only to the equivalent method on the vector class, using the same inputs
+            return DoubleVector
+                .fromMemorySegment(this, ms, offset, bo);
         }
 
         @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3747,9 +3747,19 @@ public abstract class FloatVector extends AbstractVector<Float> {
         @ForceInline
         @Override final
         public FloatVector fromArray(Object a, int offset) {
-            // User entry point:  Be careful with inputs.
+            // User entry point
+            // Defer only to the equivalent method on the vector class, using the same inputs
             return FloatVector
                 .fromArray(this, (float[]) a, offset);
+        }
+
+        @ForceInline
+        @Override final
+        public FloatVector fromMemorySegment(MemorySegment ms, long offset, ByteOrder bo) {
+            // User entry point
+            // Defer only to the equivalent method on the vector class, using the same inputs
+            return FloatVector
+                .fromMemorySegment(this, ms, offset, bo);
         }
 
         @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3903,9 +3903,19 @@ public abstract class IntVector extends AbstractVector<Integer> {
         @ForceInline
         @Override final
         public IntVector fromArray(Object a, int offset) {
-            // User entry point:  Be careful with inputs.
+            // User entry point
+            // Defer only to the equivalent method on the vector class, using the same inputs
             return IntVector
                 .fromArray(this, (int[]) a, offset);
+        }
+
+        @ForceInline
+        @Override final
+        public IntVector fromMemorySegment(MemorySegment ms, long offset, ByteOrder bo) {
+            // User entry point
+            // Defer only to the equivalent method on the vector class, using the same inputs
+            return IntVector
+                .fromMemorySegment(this, ms, offset, bo);
         }
 
         @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3829,9 +3829,19 @@ public abstract class LongVector extends AbstractVector<Long> {
         @ForceInline
         @Override final
         public LongVector fromArray(Object a, int offset) {
-            // User entry point:  Be careful with inputs.
+            // User entry point
+            // Defer only to the equivalent method on the vector class, using the same inputs
             return LongVector
                 .fromArray(this, (long[]) a, offset);
+        }
+
+        @ForceInline
+        @Override final
+        public LongVector fromMemorySegment(MemorySegment ms, long offset, ByteOrder bo) {
+            // User entry point
+            // Defer only to the equivalent method on the vector class, using the same inputs
+            return LongVector
+                .fromMemorySegment(this, ms, offset, bo);
         }
 
         @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -4188,9 +4188,19 @@ public abstract class ShortVector extends AbstractVector<Short> {
         @ForceInline
         @Override final
         public ShortVector fromArray(Object a, int offset) {
-            // User entry point:  Be careful with inputs.
+            // User entry point
+            // Defer only to the equivalent method on the vector class, using the same inputs
             return ShortVector
                 .fromArray(this, (short[]) a, offset);
+        }
+
+        @ForceInline
+        @Override final
+        public ShortVector fromMemorySegment(MemorySegment ms, long offset, ByteOrder bo) {
+            // User entry point
+            // Defer only to the equivalent method on the vector class, using the same inputs
+            return ShortVector
+                .fromMemorySegment(this, ms, offset, bo);
         }
 
         @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -5453,9 +5453,19 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         @ForceInline
         @Override final
         public $abstractvectortype$ fromArray(Object a, int offset) {
-            // User entry point:  Be careful with inputs.
+            // User entry point
+            // Defer only to the equivalent method on the vector class, using the same inputs
             return $abstractvectortype$
                 .fromArray(this, ($type$[]) a, offset);
+        }
+
+        @ForceInline
+        @Override final
+        public $abstractvectortype$ fromMemorySegment(MemorySegment ms, long offset, ByteOrder bo) {
+            // User entry point
+            // Defer only to the equivalent method on the vector class, using the same inputs
+            return $abstractvectortype$
+                .fromMemorySegment(this, ms, offset, bo);
         }
 
         @ForceInline

--- a/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte128VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static ByteVector fromArray(byte[] a, int i) {
-        return ByteVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (ByteVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Byte128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static ByteVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return ByteVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (ByteVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte256VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static ByteVector fromArray(byte[] a, int i) {
-        return ByteVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (ByteVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Byte256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static ByteVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return ByteVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (ByteVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte512VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static ByteVector fromArray(byte[] a, int i) {
-        return ByteVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (ByteVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Byte512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static ByteVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return ByteVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (ByteVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte64VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static ByteVector fromArray(byte[] a, int i) {
-        return ByteVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (ByteVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Byte64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static ByteVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return ByteVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (ByteVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -255,7 +255,8 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static ByteVector fromArray(byte[] a, int i) {
-        return ByteVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (ByteVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -275,7 +276,8 @@ public class ByteMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static ByteVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return ByteVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (ByteVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double128VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Double128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static DoubleVector fromArray(double[] a, int i) {
-        return DoubleVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (DoubleVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Double128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static DoubleVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return DoubleVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (DoubleVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double256VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Double256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static DoubleVector fromArray(double[] a, int i) {
-        return DoubleVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (DoubleVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Double256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static DoubleVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return DoubleVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (DoubleVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double512VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Double512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static DoubleVector fromArray(double[] a, int i) {
-        return DoubleVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (DoubleVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Double512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static DoubleVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return DoubleVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (DoubleVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Double64VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Double64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static DoubleVector fromArray(double[] a, int i) {
-        return DoubleVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (DoubleVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Double64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static DoubleVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return DoubleVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (DoubleVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -255,7 +255,8 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static DoubleVector fromArray(double[] a, int i) {
-        return DoubleVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (DoubleVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -275,7 +276,8 @@ public class DoubleMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static DoubleVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return DoubleVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (DoubleVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float128VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Float128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static FloatVector fromArray(float[] a, int i) {
-        return FloatVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (FloatVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Float128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static FloatVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return FloatVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (FloatVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float256VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Float256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static FloatVector fromArray(float[] a, int i) {
-        return FloatVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (FloatVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Float256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static FloatVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return FloatVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (FloatVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float512VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Float512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static FloatVector fromArray(float[] a, int i) {
-        return FloatVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (FloatVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Float512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static FloatVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return FloatVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (FloatVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Float64VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Float64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static FloatVector fromArray(float[] a, int i) {
-        return FloatVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (FloatVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Float64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static FloatVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return FloatVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (FloatVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -255,7 +255,8 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static FloatVector fromArray(float[] a, int i) {
-        return FloatVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (FloatVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -275,7 +276,8 @@ public class FloatMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static FloatVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return FloatVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (FloatVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int128VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Int128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static IntVector fromArray(int[] a, int i) {
-        return IntVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (IntVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Int128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static IntVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return IntVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (IntVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int256VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Int256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static IntVector fromArray(int[] a, int i) {
-        return IntVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (IntVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Int256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static IntVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return IntVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (IntVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int512VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Int512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static IntVector fromArray(int[] a, int i) {
-        return IntVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (IntVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Int512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static IntVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return IntVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (IntVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Int64VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Int64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static IntVector fromArray(int[] a, int i) {
-        return IntVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (IntVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Int64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static IntVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return IntVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (IntVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/IntMaxVectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -255,7 +255,8 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static IntVector fromArray(int[] a, int i) {
-        return IntVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (IntVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -275,7 +276,8 @@ public class IntMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static IntVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return IntVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (IntVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long128VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Long128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static LongVector fromArray(long[] a, int i) {
-        return LongVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (LongVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Long128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static LongVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return LongVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (LongVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long256VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Long256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static LongVector fromArray(long[] a, int i) {
-        return LongVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (LongVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Long256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static LongVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return LongVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (LongVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long512VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Long512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static LongVector fromArray(long[] a, int i) {
-        return LongVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (LongVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Long512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static LongVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return LongVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (LongVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Long64VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Long64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static LongVector fromArray(long[] a, int i) {
-        return LongVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (LongVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Long64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static LongVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return LongVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (LongVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/LongMaxVectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -255,7 +255,8 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static LongVector fromArray(long[] a, int i) {
-        return LongVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (LongVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -275,7 +276,8 @@ public class LongMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static LongVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return LongVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (LongVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short128VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Short128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static ShortVector fromArray(short[] a, int i) {
-        return ShortVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (ShortVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Short128VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static ShortVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return ShortVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (ShortVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short256VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Short256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static ShortVector fromArray(short[] a, int i) {
-        return ShortVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (ShortVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Short256VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static ShortVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return ShortVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (ShortVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short512VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Short512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static ShortVector fromArray(short[] a, int i) {
-        return ShortVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (ShortVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Short512VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static ShortVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return ShortVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (ShortVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/Short64VectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,8 @@ public class Short64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static ShortVector fromArray(short[] a, int i) {
-        return ShortVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (ShortVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -268,7 +269,8 @@ public class Short64VectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static ShortVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return ShortVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (ShortVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
+++ b/test/jdk/jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -255,7 +255,8 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static ShortVector fromArray(short[] a, int i) {
-        return ShortVector.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return (ShortVector) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -275,7 +276,8 @@ public class ShortMaxVectorLoadStoreTests extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static ShortVector fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return ShortVector.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return (ShortVector) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline

--- a/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
+++ b/test/jdk/jdk/incubator/vector/templates/X-LoadStoreTest.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -268,7 +268,8 @@ public class $vectorteststype$ extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static $abstractvectortype$ fromArray($type$[] a, int i) {
-        return $abstractvectortype$.fromArray(SPECIES, a, i);
+        // Tests the species method and the equivalent vector method it defers to
+        return ($abstractvectortype$) SPECIES.fromArray(a, i);
     }
 
     @DontInline
@@ -288,7 +289,8 @@ public class $vectorteststype$ extends AbstractVectorLoadStoreTest {
 
     @DontInline
     static $abstractvectortype$ fromMemorySegment(MemorySegment a, int i, ByteOrder bo) {
-        return $abstractvectortype$.fromMemorySegment(SPECIES, a, i, bo);
+        // Tests the species method and the equivalent vector method it defers to
+        return ($abstractvectortype$) SPECIES.fromMemorySegment(a, i, bo);
     }
 
     @DontInline


### PR DESCRIPTION
This pull request contains a backport of commit [1ae85138](https://github.com/openjdk/jdk/commit/1ae851387f881263ccc6aeace5afdd0f49d41d33) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Paul Sandoz on 2 Feb 2024 and was reviewed by Maurizio Cimadamore and Jatin Bhateja.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324858](https://bugs.openjdk.org/browse/JDK-8324858): [vectorapi] Bounds checking issues when accessing memory segments (**Bug** - P2)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk22.git pull/109/head:pull/109` \
`$ git checkout pull/109`

Update a local copy of the PR: \
`$ git checkout pull/109` \
`$ git pull https://git.openjdk.org/jdk22.git pull/109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 109`

View PR using the GUI difftool: \
`$ git pr show -t 109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk22/pull/109.diff">https://git.openjdk.org/jdk22/pull/109.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk22/pull/109#issuecomment-1930360407)